### PR TITLE
Add scoping to file handles

### DIFF
--- a/Assets/NaughtyAttributes/Scripts/Editor/Utility/IOUtility.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/Utility/IOUtility.cs
@@ -12,11 +12,9 @@ namespace NaughtyAttributes.Editor
 
         public static void WriteToFile(string filePath, string content)
         {
-            FileStream fileStream = new FileStream(filePath, FileMode.Create, FileAccess.Write);
-            using (fileStream)
+            using (FileStream fileStream = new FileStream(filePath, FileMode.Create, FileAccess.Write))
             {
-                StreamWriter streamWriter = new StreamWriter(fileStream, System.Text.Encoding.ASCII);
-                using (streamWriter)
+                using (StreamWriter streamWriter = new StreamWriter(fileStream, System.Text.Encoding.ASCII))
                 {
                     streamWriter.WriteLine(content);
                 }
@@ -25,11 +23,9 @@ namespace NaughtyAttributes.Editor
 
         public static string ReadFromFile(string filePath)
         {
-            FileStream fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read);
-            using (fileStream)
+            using (FileStream fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read))
             {
-                StreamReader streamReader = new StreamReader(fileStream, System.Text.Encoding.ASCII);
-                using (streamReader)
+                using (StreamReader streamReader = new StreamReader(fileStream, System.Text.Encoding.ASCII))
                 {
                     string content = streamReader.ReadToEnd();
                     return content;


### PR DESCRIPTION
Instantiating an IDisposible outside of the using statement can lead to unforseen issues as the object can be accessed after being disposed leading further to issues of partially destroyed objects and funky exceptions.

source: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-statement