### PR TITLE
Add bool drawing to DrawLayoutField

### DIFF
--- a/Assets/Plugins/NaughtyAttributes/Scripts/Editor/Utility/EditorDrawUtility.cs
+++ b/Assets/Plugins/NaughtyAttributes/Scripts/Editor/Utility/EditorDrawUtility.cs
@@ -61,6 +61,10 @@ namespace NaughtyAttributes.Editor
                 isDrawn = true;
                 EditorGUILayout.TextField(label, (string)value);
             }
+            else if (valueType == typeof(bool)) {
+                isDrawn = true;
+                EditorGUILayout.Toggle(label, (bool)value);
+            }
             else if (valueType == typeof(Vector2))
             {
                 isDrawn = true;


### PR DESCRIPTION
This allows boolean values to be drawn using "ShowNativeProperty" and "ShowNonSerializedField"