### PR TITLE
add HideIfAny & HideIfAll Attribute (DrawConditionAttribute)

### DIFF
--- a/Assets/Plugins/NaughtyAttributes/Scripts/Core/DrawConditionAttributes/HideIfAllAttribute.cs
+++ b/Assets/Plugins/NaughtyAttributes/Scripts/Core/DrawConditionAttributes/HideIfAllAttribute.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace NaughtyAttributes
+{
+    [AttributeUsage(AttributeTargets.Field, AllowMultiple = true, Inherited = true)]
+    public class HideIfAllAttribute : DrawConditionAttribute
+    {
+        public string ConditionName { get; private set; }
+
+        public bool ConditionValue { get; private set; }
+
+        public HideIfAllAttribute(string conditionName, bool conditionValue = true)
+        {
+            this.ConditionName = conditionName;
+            this.ConditionValue = conditionValue;
+        }
+    }
+}

--- a/Assets/Plugins/NaughtyAttributes/Scripts/Core/DrawConditionAttributes/HideIfAllAttribute.cs.meta
+++ b/Assets/Plugins/NaughtyAttributes/Scripts/Core/DrawConditionAttributes/HideIfAllAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9d6bed808c6bbda4aa1171fb610a14b4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/NaughtyAttributes/Scripts/Core/DrawConditionAttributes/HideIfAnyAttribute.cs
+++ b/Assets/Plugins/NaughtyAttributes/Scripts/Core/DrawConditionAttributes/HideIfAnyAttribute.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace NaughtyAttributes
+{
+    [AttributeUsage(AttributeTargets.Field, AllowMultiple = true, Inherited = true)]
+    public class HideIfAnyAttribute : DrawConditionAttribute
+    {
+        public string ConditionName { get; private set; }
+
+        public bool ConditionValue { get; private set; }
+
+        public HideIfAnyAttribute(string conditionName, bool conditionValue = true)
+        {
+            this.ConditionName = conditionName;
+            this.ConditionValue = conditionValue;
+        }
+    }
+}

--- a/Assets/Plugins/NaughtyAttributes/Scripts/Core/DrawConditionAttributes/HideIfAnyAttribute.cs.meta
+++ b/Assets/Plugins/NaughtyAttributes/Scripts/Core/DrawConditionAttributes/HideIfAnyAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d2066299b594dbb41a1c1409c637a629
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/NaughtyAttributes/Scripts/Editor/CodeGeneration/PropertyDrawConditionDatabase.cs
+++ b/Assets/Plugins/NaughtyAttributes/Scripts/Editor/CodeGeneration/PropertyDrawConditionDatabase.cs
@@ -13,7 +13,9 @@ namespace NaughtyAttributes.Editor
         {
             drawConditionsByAttributeType = new Dictionary<Type, PropertyDrawCondition>();
             drawConditionsByAttributeType[typeof(HideIfAttribute)] = new HideIfPropertyDrawCondition();
-drawConditionsByAttributeType[typeof(ShowIfAttribute)] = new ShowIfPropertyDrawCondition();
+            drawConditionsByAttributeType[typeof(ShowIfAttribute)] = new ShowIfPropertyDrawCondition();
+            drawConditionsByAttributeType[typeof(HideIfAnyAttribute)] = new HideIfAnyPropertyDrawCondition();
+            drawConditionsByAttributeType[typeof(HideIfAllAttribute)] = new HideIfAllPropertyDrawCondition();
 
         }
 

--- a/Assets/Plugins/NaughtyAttributes/Scripts/Editor/PropertyDrawConditions/HideIfAllPropertyDrawCondition.cs
+++ b/Assets/Plugins/NaughtyAttributes/Scripts/Editor/PropertyDrawConditions/HideIfAllPropertyDrawCondition.cs
@@ -1,0 +1,52 @@
+﻿using System.Reflection;
+using UnityEditor;
+
+namespace NaughtyAttributes.Editor
+{
+    [PropertyDrawCondition(typeof(HideIfAllAttribute))]
+    public class HideIfAllPropertyDrawCondition : PropertyDrawCondition
+    {
+        public override bool CanDrawProperty(SerializedProperty property)
+        {
+            HideIfAllAttribute[] hideIfAllAttributes = PropertyUtility.GetAttributes<HideIfAllAttribute>(property);
+            UnityEngine.Object target = PropertyUtility.GetTargetObject(property);
+
+            foreach (var attribute in hideIfAllAttributes)
+            {
+                FieldInfo conditionField = ReflectionUtility.GetField(target, attribute.ConditionName);
+                if (conditionField != null &&
+                    conditionField.FieldType == typeof(bool))
+                {
+                    if ((bool)conditionField.GetValue(target) != attribute.ConditionValue)
+                    {
+                        return true;
+                    }
+                    else
+                    {
+                        continue;
+                    }
+                }
+
+                MethodInfo conditionMethod = ReflectionUtility.GetMethod(target, attribute.ConditionName);
+                if (conditionMethod != null &&
+                    conditionMethod.ReturnType == typeof(bool) &&
+                    conditionMethod.GetParameters().Length == 0)
+                {
+                    if ((bool)conditionMethod.Invoke(target, null) != attribute.ConditionValue)
+                    {
+                        return true;
+                    }
+                    else
+                    {
+                        continue;
+                    }
+                }
+
+                string warning = attribute.GetType().Name + " needs a valid boolean condition field or method name to work";
+                EditorDrawUtility.DrawHelpBox(warning, MessageType.Warning, logToConsole: true, context: target);
+            }
+
+            return false;
+        }
+    }
+}

--- a/Assets/Plugins/NaughtyAttributes/Scripts/Editor/PropertyDrawConditions/HideIfAllPropertyDrawCondition.cs.meta
+++ b/Assets/Plugins/NaughtyAttributes/Scripts/Editor/PropertyDrawConditions/HideIfAllPropertyDrawCondition.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5a3aaa1c43743b94ba16deef61d0295b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/NaughtyAttributes/Scripts/Editor/PropertyDrawConditions/HideIfAnyPropertyDrawCondition.cs
+++ b/Assets/Plugins/NaughtyAttributes/Scripts/Editor/PropertyDrawConditions/HideIfAnyPropertyDrawCondition.cs
@@ -1,0 +1,52 @@
+﻿using System.Reflection;
+using UnityEditor;
+
+namespace NaughtyAttributes.Editor
+{
+    [PropertyDrawCondition(typeof(HideIfAnyAttribute))]
+    public class HideIfAnyPropertyDrawCondition : PropertyDrawCondition
+    {
+        public override bool CanDrawProperty(SerializedProperty property)
+        {
+            HideIfAnyAttribute[] hideIfAnyAttributes = PropertyUtility.GetAttributes<HideIfAnyAttribute>(property);
+            UnityEngine.Object target = PropertyUtility.GetTargetObject(property);
+
+            foreach (var attribute in hideIfAnyAttributes)
+            {
+                FieldInfo conditionField = ReflectionUtility.GetField(target, attribute.ConditionName);
+                if (conditionField != null &&
+                    conditionField.FieldType == typeof(bool))
+                {
+                    if ((bool)conditionField.GetValue(target) == attribute.ConditionValue)
+                    {
+                        return false;
+                    }
+                    else
+                    {
+                        continue;
+                    }
+                }
+
+                MethodInfo conditionMethod = ReflectionUtility.GetMethod(target, attribute.ConditionName);
+                if (conditionMethod != null &&
+                    conditionMethod.ReturnType == typeof(bool) &&
+                    conditionMethod.GetParameters().Length == 0)
+                {
+                    if ((bool)conditionMethod.Invoke(target, null) == attribute.ConditionValue)
+                    {
+                        return false;
+                    }
+                    else
+                    {
+                        continue;
+                    }
+                }
+
+                string warning = attribute.GetType().Name + " needs a valid boolean condition field or method name to work";
+                EditorDrawUtility.DrawHelpBox(warning, MessageType.Warning, logToConsole: true, context: target);
+            }
+
+            return true;
+        }
+    }
+}

--- a/Assets/Plugins/NaughtyAttributes/Scripts/Editor/PropertyDrawConditions/HideIfAnyPropertyDrawCondition.cs.meta
+++ b/Assets/Plugins/NaughtyAttributes/Scripts/Editor/PropertyDrawConditions/HideIfAnyPropertyDrawCondition.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fb719aa55e14cb8488a11a158d137555
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/NaughtyAttributes/Scripts/Test/NaughtyHideIfEx.cs
+++ b/Assets/Plugins/NaughtyAttributes/Scripts/Test/NaughtyHideIfEx.cs
@@ -1,0 +1,27 @@
+﻿using NaughtyAttributes;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class NaughtyHideIfEx : MonoBehaviour
+{
+    public bool Bool1 = true;
+    public bool Bool2 = false;
+
+    [HideIfAny("Bool1")]
+    [HideIfAny("Bool2")]
+    public int HideIfAny;
+
+
+    [HideIfAll("Bool1")]
+    [HideIfAll("Bool2")]
+    public int HideIfAll;
+
+
+    [HideIfAny("Bool1", false)]
+    [HideIfAny("Bool2", false)]
+    public int HideIfAnyFalse;
+
+    [HideIfAll("Bool1", false)]
+    [HideIfAll("Bool2", false)]
+    public int HideIfAllFalse;
+}

--- a/Assets/Plugins/NaughtyAttributes/Scripts/Test/NaughtyHideIfEx.cs.meta
+++ b/Assets/Plugins/NaughtyAttributes/Scripts/Test/NaughtyHideIfEx.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 688f191969c5595469e2f9f34d155c1c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
A field can have more than one DrawConditionAttribute(HideIf/ShowIf) by using HideIfAny/HideIfAll Attributes.
HideIfAnyAttribute: Hide the field if ANY condition is true*
HideIfAllAttribute: Hide the field if ALL conditions are true*
(true: if the condition is equal to HideIfAny(All)Attribute.ConditionValue, initialized in ctor)