### PR TITLE
Make ButtonMethodDrawer work in Prefab mode

### DIFF
--- a/Assets/Plugins/NaughtyAttributes/Scripts/Editor/MethodDrawers/ButtonMethodDrawer.cs
+++ b/Assets/Plugins/NaughtyAttributes/Scripts/Editor/MethodDrawers/ButtonMethodDrawer.cs
@@ -1,5 +1,7 @@
 using System.Reflection;
 using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEditor.Experimental.SceneManagement;
 using UnityEngine;
 
 namespace NaughtyAttributes.Editor
@@ -17,6 +19,12 @@ namespace NaughtyAttributes.Editor
                 if (GUILayout.Button(buttonText))
                 {
                     methodInfo.Invoke(target, null);
+                    
+                    // set prefab scene as dirty to flush changes in prefab mode
+                    var stage = PrefabStageUtility.GetCurrentPrefabStage();
+                    if (stage != null) {
+                        EditorSceneManager.MarkSceneDirty(stage.scene);
+                    }
                 }
             }
             else


### PR DESCRIPTION
Not sure if this is the best approach, but if we try to change a component's field value via [Button] attribute while in Prefab mode, the changes won't be flushed to disk. (Because we are not working with SerializedProperties or SerializedObject.)

This is the suggested method to trigger a flush to disk by Unity team, it is also what happens when you change a value by hand in Prefab mode: the scene is marked as dirty, then a save is done automatically.

https://issuetracker.unity3d.com/issues/changes-made-to-a-variable-of-a-script-are-not-saved-when-they-are-made-inside-the-prefab-mode-even-with-autosave-enabled