### PR TITLE
Support fields, properties or methods as a source for dropdown values

### DIFF
--- a/Assets/Plugins/NaughtyAttributes/Scripts/Test/Dropdowns.cs
+++ b/Assets/Plugins/NaughtyAttributes/Scripts/Test/Dropdowns.cs
@@ -18,11 +18,17 @@ public class Dropdowns : MonoBehaviour
 
     private List<string> stringValues = new List<string>() { "A", "B", "C" };
 
-    private DropdownList<Vector3> vectorValues = new DropdownList<Vector3>()
+    private DropdownList<Vector3> vectorValues
     {
-        { "Right", Vector3.right },
-        { "Up", Vector3.up },
-        { "Forward", Vector3.forward }
-    };
+        get
+        {
+            return new DropdownList<Vector3>()
+            {
+                { "Right", Vector3.right },
+                { "Up", Vector3.up },
+                { "Forward", Vector3.forward }
+            };
+        }
+    }
 #pragma warning restore 414
 }


### PR DESCRIPTION
I have a project where the values for the dropdown are created in the inspector, which eliminates the support for a field. Instead, a property or a method is needed.

In addition to the workaround presented in the issue #12, this enhancement will support fields, properties and methods as a source for dropdown values.