### PR TITLE
Don't use backslashes on non-Windows.

### DIFF
--- a/Assets/NaughtyAttributes/Scripts/Editor/CodeGeneration/CodeGenerator.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/CodeGeneration/CodeGenerator.cs
@@ -12,8 +12,11 @@ namespace NaughtyAttributes.Editor
     {
         private static readonly string GENERATED_CODE_TARGET_FOLDER =
             (Application.dataPath.Replace("Assets", string.Empty) + AssetDatabase.GUIDToAssetPath(AssetDatabase.FindAssets("CodeGenerator")[0]))
-            .Replace("CodeGenerator.cs", string.Empty)
-            .Replace("/", "\\");
+#if UNITY_EDITOR_WIN
+            .Replace("CodeGenerator.cs", string.Empty).Replace("/", "\\");
+#else 
+            .Replace("CodeGenerator.cs", string.Empty);
+#endif 
 
         private static readonly string CLASS_NAME_PLACEHOLDER = "__classname__";
         private static readonly string ENTRIES_PLACEHOLDER = "__entries__";


### PR DESCRIPTION
This should resolve issue #35. There are other ways to accomplish this. Most of the Windows API accepts forward slashes also, so only convert where absolutely necessary. Seems that this was a .NET 3.5 vs .NET 4.x problem.