### PR TITLE
GetSetAttribute

### DIFF
--- a/Assets/NaughtyAttributes/Scripts/Core/DrawerAttributes/GetSetAttribute.cs
+++ b/Assets/NaughtyAttributes/Scripts/Core/DrawerAttributes/GetSetAttribute.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace NaughtyAttributes
+{
+    /// <summary>
+    /// Trigger a Get and Set calls in a Property from a modifying a Field in the Inspector
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field, AllowMultiple = false, Inherited = true)]
+    public class GetSetAttribute : DrawerAttribute
+    {
+        public readonly string PropertyName;
+
+        public GetSetAttribute(string propertyName)
+        {
+            PropertyName = propertyName;
+        }
+    }
+}

--- a/Assets/NaughtyAttributes/Scripts/Core/DrawerAttributes/GetSetAttribute.cs.meta
+++ b/Assets/NaughtyAttributes/Scripts/Core/DrawerAttributes/GetSetAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 14f1792a617ca1c4bb5417189043ecba
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/NaughtyAttributes/Scripts/Editor/CodeGeneration/PropertyDrawerDatabase.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/CodeGeneration/PropertyDrawerDatabase.cs
@@ -15,6 +15,7 @@ namespace NaughtyAttributes.Editor
             drawersByAttributeType[typeof(DisableIfAttribute)] = new DisableIfPropertyDrawer();
 drawersByAttributeType[typeof(DropdownAttribute)] = new DropdownPropertyDrawer();
 drawersByAttributeType[typeof(EnableIfAttribute)] = new EnableIfPropertyDrawer();
+drawersByAttributeType[typeof(GetSetAttribute)] = new GetSetPropertyDrawer();
 drawersByAttributeType[typeof(LabelAttribute)] = new LabelPropertyDrawer();
 drawersByAttributeType[typeof(MinMaxSliderAttribute)] = new MinMaxSliderPropertyDrawer();
 drawersByAttributeType[typeof(ProgressBarAttribute)] = new ProgressBarPropertyDrawer();

--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/GetSetPropertyDrawer.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/GetSetPropertyDrawer.cs
@@ -1,0 +1,51 @@
+using UnityEngine;
+using UnityEditor;
+using System.Reflection;
+
+namespace NaughtyAttributes.Editor
+{
+    [PropertyDrawer(typeof(GetSetAttribute))]
+    public class GetSetPropertyDrawer : PropertyDrawer
+    {
+        public override void DrawProperty(SerializedProperty property)
+        {
+            var getSetAttribute = PropertyUtility.GetAttribute<GetSetAttribute>(property);
+
+            EditorGUI.BeginChangeCheck();
+            var guiContent = new GUIContent(property.displayName);
+            EditorGUILayout.PropertyField(property, guiContent, true);
+
+            if (EditorGUI.EndChangeCheck())
+            {
+                var parent = GetParentObject(property.propertyPath, property.serializedObject.targetObject);
+                var type = parent.GetType();
+                var fieldInfo = type.GetField(property.propertyPath, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+                var propertyInfo = type.GetProperty(getSetAttribute.PropertyName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+
+                if (propertyInfo == null)
+                {
+                    Debug.LogError("Invalid property name \"" + getSetAttribute.PropertyName + "\"");
+                }
+                else
+                {
+                    propertyInfo.SetValue(parent, fieldInfo.GetValue(parent), null);
+                }
+            }
+        }
+
+        public static object GetParentObject(string path, object obj)
+        {
+            var fields = path.Split('.');
+
+            if (fields.Length == 1)
+            {
+                return obj;
+            }
+
+            FieldInfo info = obj.GetType().GetField(fields[0], BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            obj = info.GetValue(obj);
+
+            return GetParentObject(string.Join(".", fields, 1, fields.Length - 1), obj);
+        }
+    }
+}

--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/GetSetPropertyDrawer.cs.meta
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/GetSetPropertyDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6ef0d8399c4b8614ab38da2e166e1075
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/NaughtyAttributes/Scripts/Test/GetSetProperties.cs
+++ b/Assets/NaughtyAttributes/Scripts/Test/GetSetProperties.cs
@@ -1,0 +1,34 @@
+﻿using UnityEngine;
+using NaughtyAttributes;
+
+public class GetSetProperties : MonoBehaviour
+{
+    [SerializeField, GetSet("MyInt")]
+    private int _MyInt;
+    public int MyInt
+    {
+        get
+        {
+            print("Getting");
+            return _MyInt;
+        }
+        set
+        {
+            print("Setting");
+            _MyInt = value;
+        }
+    }
+
+
+    [Button]
+    private void IncrementProperty()
+    {
+        MyInt++;
+    }
+
+    [Button]
+    private void ReadProperty()
+    {
+        var i = MyInt;
+    }
+}

--- a/Assets/NaughtyAttributes/Scripts/Test/GetSetProperties.cs.meta
+++ b/Assets/NaughtyAttributes/Scripts/Test/GetSetProperties.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ea96e390ca028174dab76eed6ccfdff7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/NaughtyAttributes/_Scenes/DemoScene.unity
+++ b/Assets/NaughtyAttributes/_Scenes/DemoScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657874, g: 0.49641258, b: 0.5748172, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -328,6 +328,7 @@ GameObject:
   - component: {fileID: 2033251975}
   - component: {fileID: 2033251989}
   - component: {fileID: 2033251988}
+  - component: {fileID: 2033251990}
   m_Layer: 0
   m_Name: TestObject
   m_TagString: Untagged
@@ -601,3 +602,16 @@ MonoBehaviour:
   myClass:
     aInt: 0
     aString: 
+--- !u!114 &2033251990
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2033251972}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ea96e390ca028174dab76eed6ccfdff7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _MyInt: 0


### PR DESCRIPTION
Trigger a Get and Set calls in a Property from a modifying a Field in the Inspector
[GetSet("PropertyName")]
private int _Field;
public int PropertyName=> _Field;

Useful when using Observer pattern in Properties when you want to get notified on value changes, this makes it possible to get triggered also when changing the values in the inspector