### PR TITLE
Change ReorderableList to use property's height instead of 0.0f

### DIFF
--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/ReorderableListPropertyDrawer.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/ReorderableListPropertyDrawer.cs
@@ -39,7 +39,7 @@ namespace NaughtyAttributes.Editor
                             rect.x += 10.0f;
                             rect.width -= 10.0f;
 
-                            EditorGUI.PropertyField(new Rect(rect.x, rect.y, rect.width, 0.0f), element, true);
+                            EditorGUI.PropertyField(new Rect(rect.x, rect.y, rect.width, rect.height), element, true);
                         },
 
                         elementHeightCallback = (int index) =>


### PR DESCRIPTION
This seems to fix custom PropertyDrawers that rely on their OnGUI event getting the right height value.
I found the issue using [JohannesMP's SceneReference](https://gist.github.com/JohannesMP/ec7d3f0bcf167dab3d0d3bb480e0e07b) property drawer, which uses OnGUI's given height to draw its background.

Tests before: https://i.imgur.com/whEVtat.png
Tests after: https://i.imgur.com/2oLVBph.png (no effect)

Scene list before: https://i.imgur.com/5kBTL4d.png (broken backgrounds on lower properties)
Scene list after: https://i.imgur.com/vxj1Knj.png (fixed)