### PR TITLE
Fixed Reorderable List Rect Height

### DIFF
--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/ReorderableListPropertyDrawer.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/ReorderableListPropertyDrawer.cs
@@ -39,7 +39,7 @@ namespace NaughtyAttributes.Editor
                             rect.x += 10.0f;
                             rect.width -= 10.0f;
 
-                            EditorGUI.PropertyField(new Rect(rect.x, rect.y, rect.width, 0.0f), element, true);
+                            EditorGUI.PropertyField(new Rect(rect.x, rect.y, rect.width, EditorGUIUtility.singleLineHeight), element, true);
                         },
 
                         elementHeightCallback = (int index) =>


### PR DESCRIPTION
Small fix that resets the ReorderableListPropertyDrawer's Property field height to the value of EditorUtility.singleLineHeight as it was changed to zero and did send a zero-height Rect to fields rendered with custom property drawers.

Behaviour with Multi-Line Array Items does not seem affected.

Before Fix:
![image](https://user-images.githubusercontent.com/4037271/65368206-6d384c80-dc3e-11e9-9b3d-a877b94bf904.png)

After Fix:
![image](https://user-images.githubusercontent.com/4037271/65368199-48dc7000-dc3e-11e9-9dae-a997dc8a4622.png)
