### PR TITLE
Added EnableMode to Button

### DIFF
--- a/Assets/NaughtyAttributes/Scripts/Core/DrawerAttributes/ButtonAttribute.cs
+++ b/Assets/NaughtyAttributes/Scripts/Core/DrawerAttributes/ButtonAttribute.cs
@@ -5,11 +5,31 @@ namespace NaughtyAttributes
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
     public class ButtonAttribute : DrawerAttribute
     {
-        public string Text { get; private set; }
+        public enum EnableMode
+        {
+            /// <summary>
+            /// Button should be active always
+            /// </summary>
+            Always,
+            /// <summary>
+            /// Button should be active only in editor
+            /// </summary>
+            Editor,
+            /// <summary>
+            /// Button should be active only in playmode
+            /// </summary>
+            Playmode
+        }
 
-        public ButtonAttribute(string text = null)
+        public string Text { get; private set; }
+        public EnableMode SelectedEnableMode { get; private set; }
+
+        /// <param name="editorActive">Should the button be shown in editor?</param>
+        /// <param name="runtimeActive">Should the button be shown when application is playing</param>
+        public ButtonAttribute(string text = null, EnableMode enabledMode = EnableMode.Always)
         {
             this.Text = text;
+            this.SelectedEnableMode = enabledMode;
         }
     }
 }

--- a/Assets/NaughtyAttributes/Scripts/Editor/MethodDrawers/ButtonMethodDrawer.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/MethodDrawers/ButtonMethodDrawer.cs
@@ -14,10 +14,20 @@ namespace NaughtyAttributes.Editor
                 ButtonAttribute buttonAttribute = (ButtonAttribute)methodInfo.GetCustomAttributes(typeof(ButtonAttribute), true)[0];
                 string buttonText = string.IsNullOrEmpty(buttonAttribute.Text) ? methodInfo.Name : buttonAttribute.Text;
 
+                ButtonAttribute.EnableMode mode = buttonAttribute.SelectedEnableMode;
+                bool buttonEnabled = buttonAttribute.SelectedEnableMode ==
+                    ButtonAttribute.EnableMode.Always ||
+                    mode == ButtonAttribute.EnableMode.Editor && !Application.isPlaying ||
+                    mode == ButtonAttribute.EnableMode.Playmode && Application.isPlaying;
+
+                EditorGUI.BeginDisabledGroup(!buttonEnabled);
+
                 if (GUILayout.Button(buttonText))
                 {
                     methodInfo.Invoke(target, null);
                 }
+
+                EditorGUI.EndDisabledGroup();
             }
             else
             {


### PR DESCRIPTION
This allows users to make Editor Only and Playmode Only Buttons. This helps when doing simple testing buttons to trigger animations and methods