### PR TITLE
Feature/use setter

### DIFF
--- a/Assets/NaughtyAttributes/Samples/DemoScene/DemoScene.unity
+++ b/Assets/NaughtyAttributes/Samples/DemoScene/DemoScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657874, g: 0.49641258, b: 0.5748172, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657844, g: 0.49641222, b: 0.57481694, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -614,4 +614,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 27220a12cecf79e4ab3eb9a68f8b988c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _myPositiveProperty: 2648
+  _testBool: 1
+  _testString: hh
+  _myPositiveProperty: 1.4

--- a/Assets/NaughtyAttributes/Samples/DemoScene/DemoScene.unity
+++ b/Assets/NaughtyAttributes/Samples/DemoScene/DemoScene.unity
@@ -614,4 +614,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 27220a12cecf79e4ab3eb9a68f8b988c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _myPositiveProperty: 42
+  _myPositiveProperty: 2648

--- a/Assets/NaughtyAttributes/Samples/DemoScene/DemoScene.unity
+++ b/Assets/NaughtyAttributes/Samples/DemoScene/DemoScene.unity
@@ -94,8 +94,8 @@ LightmapSettings:
     m_PVRFilteringAtrousPositionSigmaDirect: 0.5
     m_PVRFilteringAtrousPositionSigmaIndirect: 2
     m_PVRFilteringAtrousPositionSigmaAO: 1
-    m_ShowResolutionOverlay: 1
     m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
   m_LightingDataAsset: {fileID: 0}
   m_UseShadowmask: 1
 --- !u!196 &4
@@ -328,6 +328,7 @@ GameObject:
   - component: {fileID: 2033251975}
   - component: {fileID: 2033251989}
   - component: {fileID: 2033251988}
+  - component: {fileID: 2033251990}
   m_Layer: 0
   m_Name: TestObject
   m_TagString: Untagged
@@ -601,3 +602,16 @@ MonoBehaviour:
   myClass:
     aInt: 0
     aString: 
+--- !u!114 &2033251990
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2033251972}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 27220a12cecf79e4ab3eb9a68f8b988c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _myPositiveProperty: 42

--- a/Assets/NaughtyAttributes/Scripts/Core/DrawerAttributes/UsePropertySetterAttribute.cs
+++ b/Assets/NaughtyAttributes/Scripts/Core/DrawerAttributes/UsePropertySetterAttribute.cs
@@ -1,0 +1,25 @@
+﻿namespace NaughtyAttributes
+{
+    /// <summary>
+    /// Use this on a private serialized member that is exposed via a public property. 
+    /// When setting its value in the inspector, it will be done via the property setter instead of skipping it.
+    /// <para>If the property name matches the name displayed on the inspector without spaces, the name parameter can be omitted.</para>
+    /// </summary>
+    public class UsePropertySetterAttribute : DrawerAttribute
+    {
+        public readonly string propertyName;
+        public readonly bool autoFindProperty;
+
+        public UsePropertySetterAttribute()
+        {
+            propertyName = null;
+            autoFindProperty = true;
+        }
+
+        public UsePropertySetterAttribute(string propertyName)
+        {
+            this.propertyName = propertyName;
+            autoFindProperty = false;
+        }
+    }
+}

--- a/Assets/NaughtyAttributes/Scripts/Core/DrawerAttributes/UsePropertySetterAttribute.cs
+++ b/Assets/NaughtyAttributes/Scripts/Core/DrawerAttributes/UsePropertySetterAttribute.cs
@@ -1,9 +1,10 @@
 ﻿namespace NaughtyAttributes
 {
     /// <summary>
-    /// Use this on a private serialized member that is exposed via a public property. 
-    /// When setting its value in the inspector, it will be done via the property setter instead of skipping it.
-    /// <para>If the property name matches the name displayed on the inspector without spaces, the name parameter can be omitted.</para>
+    /// Use this on a serialized field that is exposed through a property. 
+    /// When setting its value in the inspector, the setter will be used.
+    /// <para>If the property name matches the field's inspector display name, the name doesn't have to be provided.</para>
+    /// <para>[Delayed] use is recommended, as it avoids spamming the setter with half-written values.</para>
     /// </summary>
     public class UsePropertySetterAttribute : DrawerAttribute
     {

--- a/Assets/NaughtyAttributes/Scripts/Core/DrawerAttributes/UsePropertySetterAttribute.cs.meta
+++ b/Assets/NaughtyAttributes/Scripts/Core/DrawerAttributes/UsePropertySetterAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d996016f02387ca43995beea4b68da88
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/NaughtyAttributes/Scripts/Editor/CodeGeneration/PropertyDrawerDatabase.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/CodeGeneration/PropertyDrawerDatabase.cs
@@ -24,6 +24,7 @@ drawersByAttributeType[typeof(ResizableTextAreaAttribute)] = new ResizableTextAr
 drawersByAttributeType[typeof(ShowAssetPreviewAttribute)] = new ShowAssetPreviewPropertyDrawer();
 drawersByAttributeType[typeof(SliderAttribute)] = new SliderPropertyDrawer();
 drawersByAttributeType[typeof(TagAttribute)] = new TagPropertyDrawer();
+drawersByAttributeType[typeof(UsePropertySetterAttribute)] = new UsePropertySetterDrawer();
 
         }
 

--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/UsePropertySetterDrawer.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/UsePropertySetterDrawer.cs
@@ -38,10 +38,6 @@ namespace NaughtyAttributes.Editor
 
                 //Set the SerializedProperty value to the read value
                 ModifySerializedValue(serializedProperty, processedValue, ref warningMessage);
-                serializedProperty.serializedObject.ApplyModifiedProperties();
-
-                //Set the object dirty so that the editor picks up the changes on a prefab
-                EditorUtility.SetDirty(serializedProperty.serializedObject.targetObject);
             }
 
             //If we have a warning message, show it.

--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/UsePropertySetterDrawer.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/UsePropertySetterDrawer.cs
@@ -7,47 +7,48 @@ namespace NaughtyAttributes.Editor
     [PropertyDrawer(typeof(UsePropertySetterAttribute))]
     public class UsePropertySetterDrawer : PropertyDrawer
     {
-        //Cached objects
-        readonly private GUIContent noLabel = GUIContent.none;
-        private GUIContent labelContent = new GUIContent();
-
-
         public override void DrawProperty(SerializedProperty serializedProperty)
         {
             string warningMessage = "";
 
-            //Draw the header if it has one
-            EditorDrawUtility.DrawHeader(serializedProperty);
-
             //Find the property member
             PropertyInfo property = FindProperty(serializedProperty);
-            if (property == null)
+            if (property == null || property.SetMethod == null)
             {
                 EditorDrawUtility.DrawHelpBox($"No setter was found for member {serializedProperty.name}.",
                     MessageType.Error, logToConsole: false, context: serializedProperty.serializedObject.context);
                 return;
             }
 
-            //Draw the appropiate field and get the value entered by the user in the inspector
-            object inspectorValue;            
-            bool valueChanged = DrawControl(serializedProperty, out inspectorValue, ref warningMessage);
+            //Draw the appropiate field and get the value entered by the user in the inspector.
+            bool valueChanged = DrawControl(serializedProperty, out object valueSetInInspector, ref warningMessage);
 
-            //If the value changed, call the setter, read the resulting value and set the serialized property to that value
             if (valueChanged)
             {
+                //Support undo.
+                //TODO: As of right now, the SerializedProperty's value change is correctly undone, but the setter doesn't get called with the old value.
+                //I'm not sure if that's possible, or even if it would be better that way.
                 Undo.RecordObject(serializedProperty.serializedObject.targetObject, $"Changed {serializedProperty.displayName} in inspector.");
-                property.SetValue(serializedProperty.serializedObject.targetObject, inspectorValue);
+                
+                //Call the setter
+                property.SetValue(serializedProperty.serializedObject.targetObject, valueSetInInspector);
 
+                //Read the value after the setter
                 object processedValue = FindField(serializedProperty).GetValue(serializedProperty.serializedObject.targetObject);
-                ModifySerializedValue(serializedProperty, processedValue);
+
+                //Set the SerializedProperty value to the read value
+                ModifySerializedValue(serializedProperty, processedValue, ref warningMessage);
                 serializedProperty.serializedObject.ApplyModifiedProperties();
+
+                //Set the object dirty so that the editor picks up the changes on a prefab
+                EditorUtility.SetDirty(serializedProperty.serializedObject.targetObject);
             }
 
             //If we have a warning message, show it.
-            if (warningMessage != "")
+            if (!string.IsNullOrEmpty(warningMessage))
             {
                 warningMessage = warningMessage.Trim();
-                EditorDrawUtility.DrawHelpBox(warningMessage, MessageType.Warning, 
+                EditorDrawUtility.DrawHelpBox(warningMessage, MessageType.Warning,
                     logToConsole: false, context: serializedProperty.serializedObject.targetObject);
             }
         }
@@ -58,206 +59,101 @@ namespace NaughtyAttributes.Editor
         /// </summary>
         private bool DrawControl(SerializedProperty serializedProperty, out object newValue, ref string warningMessage)
         {
-            //Gather the needed stuff before drawing the property
-            bool isOverridenProperty = serializedProperty.isInstantiatedPrefab && serializedProperty.prefabOverride;
-            System.Type memberType = ReflectionUtility.GetField(serializedProperty.serializedObject.targetObject, serializedProperty.name).FieldType;
+            EditorGUI.BeginChangeCheck();
 
-            //Prepare the label
-            labelContent.text = serializedProperty.displayName;
-            labelContent.tooltip = GetPropertyTooltip(serializedProperty);
+            var guiContent = new GUIContent(serializedProperty.displayName, GetPropertyTooltip(serializedProperty));
+            EditorGUILayout.PropertyField(serializedProperty, guiContent, true);
+            newValue = ReadSerializedValue(serializedProperty, ref warningMessage);
 
-            //Attributes we may neeed to look for
-            RangeAttribute rangeAttribute = null;
-            DelayedAttribute delayedAttribute = null;
-            
+            return EditorGUI.EndChangeCheck();
+        } 
+
+        private object ReadSerializedValue(SerializedProperty serializedProperty, ref string warningMessage)
+        {
             object oldValue = null;
-            newValue = null;
-            bool valueChanged = false;
-
-            //Draw the label, make it bold if it's a prefab override.
-            //The exact following style given doesn't seem to matter much as long as it's a field.
-            EditorGUILayout.BeginHorizontal();
-            EditorGUILayout.PrefixLabel(labelContent, EditorStyles.objectField, isOverridenProperty ? EditorStyles.boldLabel : EditorStyles.label);
-
-            //Draw the property correctly depending on the serialized type.
-            //Get its value.
-            //Decide wether the value changed.
             switch (serializedProperty.propertyType)
             {
                 case SerializedPropertyType.Integer:
-                    rangeAttribute = PropertyUtility.GetAttribute<RangeAttribute>(serializedProperty);
-                    delayedAttribute = PropertyUtility.GetAttribute<DelayedAttribute>(serializedProperty);
-
-                    int inputIntValue;
-                    if (rangeAttribute != null) inputIntValue = EditorGUILayout.IntSlider(serializedProperty.intValue, (int)rangeAttribute.min, (int)rangeAttribute.max);
-                    else if (delayedAttribute != null) inputIntValue = EditorGUILayout.DelayedIntField(noLabel, serializedProperty.intValue);
-                    else inputIntValue = EditorGUILayout.IntField(noLabel, serializedProperty.intValue);
-
-                    newValue = inputIntValue;
-                    valueChanged = inputIntValue != serializedProperty.intValue;
+                    oldValue = serializedProperty.intValue;
                     break;
-
                 case SerializedPropertyType.Boolean:
-                    bool inputBoolValue = EditorGUILayout.Toggle(noLabel, serializedProperty.boolValue);
-                    newValue = inputBoolValue;
-                    valueChanged = inputBoolValue != serializedProperty.boolValue;
+                    oldValue = serializedProperty.boolValue;
                     break;
-
                 case SerializedPropertyType.Float:
-                    rangeAttribute = PropertyUtility.GetAttribute<RangeAttribute>(serializedProperty);
-                    delayedAttribute = PropertyUtility.GetAttribute<DelayedAttribute>(serializedProperty);
-
-                    float newFloatValue;
-                    if (rangeAttribute != null) newFloatValue = EditorGUILayout.Slider(noLabel, serializedProperty.floatValue, rangeAttribute.min, rangeAttribute.max);
-                    else if (delayedAttribute != null) newFloatValue = EditorGUILayout.DelayedFloatField(noLabel, serializedProperty.floatValue);
-                    else newFloatValue = EditorGUILayout.FloatField(noLabel, serializedProperty.floatValue);
-
-                    newValue = newFloatValue;
-                    valueChanged = newFloatValue != serializedProperty.floatValue;
+                    oldValue = serializedProperty.floatValue;
                     break;
-
                 case SerializedPropertyType.String:
-                    delayedAttribute = PropertyUtility.GetAttribute<DelayedAttribute>(serializedProperty);
-                    MultilineAttribute multilineAttribute = PropertyUtility.GetAttribute<MultilineAttribute>(serializedProperty);
-                    TextAreaAttribute textAreaAttribute = PropertyUtility.GetAttribute<TextAreaAttribute>(serializedProperty);
-
-                    if (multilineAttribute != null) warningMessage += "MultilineAttribute is not supported by UsePropertySetterAttribute.\n\n";
-                    if (textAreaAttribute != null) warningMessage += "TextAreaAttribute is not supported by UsePropertySetterAttribute.\n\n";
-
-                    string newStringValue;
-                    if (delayedAttribute != null) newStringValue = EditorGUILayout.DelayedTextField(noLabel, serializedProperty.stringValue);
-                    else newStringValue = EditorGUILayout.TextField(noLabel, serializedProperty.stringValue);
-
-                    newValue = newStringValue;
-                    valueChanged = newStringValue != serializedProperty.stringValue;
+                    oldValue = serializedProperty.stringValue;
                     break;
-
                 case SerializedPropertyType.Color:
-                    ColorUsageAttribute colorUsageAttribute = PropertyUtility.GetAttribute<ColorUsageAttribute>(serializedProperty);
-
-                    Color newColorValue;
-                    if (colorUsageAttribute != null)
-                    {
-                        newColorValue = EditorGUILayout.ColorField(noLabel, serializedProperty.colorValue, true, 
-                            colorUsageAttribute.showAlpha, colorUsageAttribute.hdr);
-                    }
-                    else
-                    {
-                        newColorValue = EditorGUILayout.ColorField(noLabel, serializedProperty.colorValue);
-                    }
-
-                    newValue = newColorValue;
-                    valueChanged = newColorValue != serializedProperty.colorValue;
+                    oldValue = serializedProperty.colorValue;
                     break;
-
                 case SerializedPropertyType.ObjectReference:
                     oldValue = serializedProperty.objectReferenceValue;
-                    newValue = EditorGUILayout.ObjectField(noLabel, serializedProperty.objectReferenceValue, memberType,
-                        !EditorUtility.IsPersistent(serializedProperty.serializedObject.targetObject));
-
-                    valueChanged = oldValue != newValue;
                     break;
-
+                case SerializedPropertyType.LayerMask:
+                    oldValue = serializedProperty.intValue;
+                    break;
                 case SerializedPropertyType.Enum:
-                    System.Array enumValues = memberType.GetEnumValues();
-                    if (serializedProperty.enumValueIndex == -1)
-                    {
-                        warningMessage += "This enum is not supported by UsePropertySetterAttribute. Enum support is a bit iffy. Sorry.\n\n";
-                    }
-                    else
-                    {
-                        System.Enum selected = (System.Enum)enumValues.GetValue(serializedProperty.enumValueIndex);
-
-                        System.Enum newEnumValue = EditorGUILayout.EnumPopup(noLabel, selected);
-
-                        newValue = newEnumValue;
-                        //Comparing the System.Enum values directly gave false positives every frame, so we compare strings.
-                        valueChanged = newEnumValue.ToString() != selected.ToString();  
-                    }
+                    oldValue = serializedProperty.enumValueIndex;
                     break;
-
                 case SerializedPropertyType.Vector2:
-                    Vector2 newVector2Value = EditorGUILayout.Vector2Field(noLabel, serializedProperty.vector2Value);
-
-                    newValue = newVector2Value;
-                    valueChanged = newVector2Value != serializedProperty.vector2Value;
+                    oldValue = serializedProperty.vector2Value;
                     break;
-
                 case SerializedPropertyType.Vector3:
-                    Vector3 newVector3Value = EditorGUILayout.Vector3Field(noLabel, serializedProperty.vector3Value);
-
-                    newValue = newVector3Value;
-                    valueChanged = newVector3Value != serializedProperty.vector3Value;
+                    oldValue = serializedProperty.vector3Value;
                     break;
                 case SerializedPropertyType.Vector4:
-                    Vector4 newVector4Value = EditorGUILayout.Vector4Field(noLabel, serializedProperty.vector4Value);
-
-                    newValue = newVector4Value;
-                    valueChanged = newVector4Value != serializedProperty.vector4Value;
+                    oldValue = serializedProperty.vector4Value;
                     break;
                 case SerializedPropertyType.Rect:
-                    Rect newRectValue = EditorGUILayout.RectField(noLabel, serializedProperty.rectValue);
-
-                    newValue = newRectValue;
-                    valueChanged = newRectValue != serializedProperty.rectValue;
+                    oldValue = serializedProperty.rectValue;
                     break;
-
+                case SerializedPropertyType.ArraySize:
+                    oldValue = serializedProperty.arraySize;
+                    break;
+                case SerializedPropertyType.Character:
+                    oldValue = serializedProperty.stringValue;
+                    break;
                 case SerializedPropertyType.AnimationCurve:
-                    AnimationCurve newAnimationCurveValue = EditorGUILayout.CurveField(noLabel, serializedProperty.animationCurveValue);
-
-                    newValue = newAnimationCurveValue;
-                    valueChanged = newAnimationCurveValue != serializedProperty.animationCurveValue;
+                    oldValue = serializedProperty.animationCurveValue;
                     break;
-
                 case SerializedPropertyType.Bounds:
-                    Bounds newBoundsValue = EditorGUILayout.BoundsField(noLabel, serializedProperty.boundsValue);
-
-                    newValue = newBoundsValue;
-                    valueChanged = newBoundsValue != serializedProperty.boundsValue;
+                    oldValue = serializedProperty.boundsValue;
                     break;
-
+                case SerializedPropertyType.Quaternion:
+                    oldValue = serializedProperty.quaternionValue;
+                    break;
+                case SerializedPropertyType.ExposedReference:
+                    oldValue = serializedProperty.exposedReferenceValue;
+                    break;
+                case SerializedPropertyType.FixedBufferSize:
+                    oldValue = serializedProperty.fixedBufferSize;
+                    break;
                 case SerializedPropertyType.Vector2Int:
-                    Vector2Int newVector2IntValue = EditorGUILayout.Vector2IntField(noLabel, serializedProperty.vector2IntValue);
-
-                    newValue = newVector2IntValue;
-                    valueChanged = newVector2IntValue != serializedProperty.vector2IntValue;
+                    oldValue = serializedProperty.vector2IntValue;
                     break;
-
                 case SerializedPropertyType.Vector3Int:
-                    Vector3Int newVector3IntValue = EditorGUILayout.Vector3IntField(noLabel, serializedProperty.vector3IntValue);
-
-                    newValue = newVector3IntValue;
-                    valueChanged = newVector3IntValue != serializedProperty.vector3IntValue;
+                    oldValue = serializedProperty.vector3IntValue;
                     break;
                 case SerializedPropertyType.RectInt:
-                    RectInt newRectIntValue = EditorGUILayout.RectIntField(noLabel, serializedProperty.rectIntValue);
-
-                    newValue = newRectIntValue;
-                    valueChanged = newRectIntValue.Equals(serializedProperty.rectIntValue);
+                    oldValue = serializedProperty.rectIntValue;
                     break;
-
                 case SerializedPropertyType.BoundsInt:
-                    BoundsInt newBoundsIntValue = EditorGUILayout.BoundsIntField(noLabel, serializedProperty.boundsIntValue);
-
-                    newValue = newBoundsIntValue;
-                    valueChanged = newBoundsIntValue != serializedProperty.boundsIntValue;
+                    oldValue = serializedProperty.boundsIntValue;
                     break;
-
                 default:
-                    warningMessage += $"{serializedProperty.propertyType} serialized types aren't supported by UsePropertySetterAttribute. \n\n";
+                    if (string.IsNullOrEmpty(warningMessage))
+                        warningMessage += $"{serializedProperty.propertyType} serialized types aren't supported by UsePropertySetterAttribute.";
+                    
                     break;
             }
-            EditorGUILayout.EndHorizontal();
 
-            return valueChanged;
+            return oldValue;
         }
 
-        /// <summary>
-        /// Sets the value at the serialized version.
-        /// </summary>
-        private void ModifySerializedValue(SerializedProperty serializedProperty, object value)
+        private void ModifySerializedValue(SerializedProperty serializedProperty, object value, ref string warningMessage)
         {
-            //Assign the value to the serialized version in the correct way depending on each serialized type
             switch (serializedProperty.propertyType)
             {
                 case SerializedPropertyType.Integer:
@@ -315,11 +211,10 @@ namespace NaughtyAttributes.Editor
                     serializedProperty.boundsIntValue = (BoundsInt)value;
                     break;
                 default:
+                    if (string.IsNullOrEmpty(warningMessage))
+                        warningMessage += $"{serializedProperty.propertyType} serialized types aren't supported by UsePropertySetterAttribute.";
                     break;
             }
-
-            //Set the object dirty so that the editor picks up the changes on the prefab
-            EditorUtility.SetDirty(serializedProperty.serializedObject.targetObject);
         }
 
         /// <summary>

--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/UsePropertySetterDrawer.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/UsePropertySetterDrawer.cs
@@ -1,0 +1,353 @@
+﻿using System.Reflection;
+using UnityEngine;
+using UnityEditor;
+
+namespace NaughtyAttributes.Editor
+{
+    [PropertyDrawer(typeof(UsePropertySetterAttribute))]
+    public class UsePropertySetterDrawer : PropertyDrawer
+    {
+        //Cached objects
+        readonly private GUIContent noLabel = GUIContent.none;
+        private GUIContent labelContent = new GUIContent();
+
+
+        public override void DrawProperty(SerializedProperty serializedProperty)
+        {
+            string warningMessage = "";
+
+            //Draw the header if it has one
+            EditorDrawUtility.DrawHeader(serializedProperty);
+
+            //Find the property member
+            PropertyInfo property = FindProperty(serializedProperty);
+            if (property == null)
+            {
+                EditorDrawUtility.DrawHelpBox($"No setter was found for member {serializedProperty.name}.",
+                    MessageType.Error, logToConsole: false, context: serializedProperty.serializedObject.context);
+                return;
+            }
+
+            //Draw the appropiate field and get the value entered by the user in the inspector
+            object inspectorValue;            
+            bool valueChanged = DrawControl(serializedProperty, out inspectorValue, ref warningMessage);
+
+            //If the value changed, call the setter, read the resulting value and set the serialized property to that value
+            if (valueChanged)
+            {
+                Undo.RecordObject(serializedProperty.serializedObject.targetObject, $"Changed {serializedProperty.displayName} in inspector.");
+                property.SetValue(serializedProperty.serializedObject.targetObject, inspectorValue);
+
+                object processedValue = FindField(serializedProperty).GetValue(serializedProperty.serializedObject.targetObject);
+                ModifySerializedValue(serializedProperty, processedValue);
+                serializedProperty.serializedObject.ApplyModifiedProperties();
+            }
+
+            //If we have a warning message, show it.
+            if (warningMessage != "")
+            {
+                warningMessage = warningMessage.Trim();
+                EditorDrawUtility.DrawHelpBox(warningMessage, MessageType.Warning, 
+                    logToConsole: false, context: serializedProperty.serializedObject.targetObject);
+            }
+        }
+
+
+        /// <summary>
+        /// Draws the appropiate control for this serialized property, returns wether the value changed and gives out the new value.
+        /// </summary>
+        private bool DrawControl(SerializedProperty serializedProperty, out object newValue, ref string warningMessage)
+        {
+            //Gather the needed stuff before drawing the property
+            bool isOverridenProperty = serializedProperty.isInstantiatedPrefab && serializedProperty.prefabOverride;
+            System.Type memberType = ReflectionUtility.GetField(serializedProperty.serializedObject.targetObject, serializedProperty.name).FieldType;
+
+            //Prepare the label
+            labelContent.text = serializedProperty.displayName;
+            labelContent.tooltip = GetPropertyTooltip(serializedProperty);
+
+            //Attributes we may neeed to look for
+            RangeAttribute rangeAttribute = null;
+            DelayedAttribute delayedAttribute = null;
+            
+            object oldValue = null;
+            newValue = null;
+            bool valueChanged = false;
+
+            //Draw the label, make it bold if it's a prefab override.
+            //The exact following style given doesn't seem to matter much as long as it's a field.
+            EditorGUILayout.BeginHorizontal();
+            EditorGUILayout.PrefixLabel(labelContent, EditorStyles.objectField, isOverridenProperty ? EditorStyles.boldLabel : EditorStyles.label);
+
+            //Draw the property correctly depending on the serialized type.
+            //Get its value.
+            //Decide wether the value changed.
+            switch (serializedProperty.propertyType)
+            {
+                case SerializedPropertyType.Integer:
+                    rangeAttribute = PropertyUtility.GetAttribute<RangeAttribute>(serializedProperty);
+                    delayedAttribute = PropertyUtility.GetAttribute<DelayedAttribute>(serializedProperty);
+
+                    int inputIntValue;
+                    if (rangeAttribute != null) inputIntValue = EditorGUILayout.IntSlider(serializedProperty.intValue, (int)rangeAttribute.min, (int)rangeAttribute.max);
+                    else if (delayedAttribute != null) inputIntValue = EditorGUILayout.DelayedIntField(noLabel, serializedProperty.intValue);
+                    else inputIntValue = EditorGUILayout.IntField(noLabel, serializedProperty.intValue);
+
+                    newValue = inputIntValue;
+                    valueChanged = inputIntValue != serializedProperty.intValue;
+                    break;
+
+                case SerializedPropertyType.Boolean:
+                    bool inputBoolValue = EditorGUILayout.Toggle(noLabel, serializedProperty.boolValue);
+                    newValue = inputBoolValue;
+                    valueChanged = inputBoolValue != serializedProperty.boolValue;
+                    break;
+
+                case SerializedPropertyType.Float:
+                    rangeAttribute = PropertyUtility.GetAttribute<RangeAttribute>(serializedProperty);
+                    delayedAttribute = PropertyUtility.GetAttribute<DelayedAttribute>(serializedProperty);
+
+                    float newFloatValue;
+                    if (rangeAttribute != null) newFloatValue = EditorGUILayout.Slider(noLabel, serializedProperty.floatValue, rangeAttribute.min, rangeAttribute.max);
+                    else if (delayedAttribute != null) newFloatValue = EditorGUILayout.DelayedFloatField(noLabel, serializedProperty.floatValue);
+                    else newFloatValue = EditorGUILayout.FloatField(noLabel, serializedProperty.floatValue);
+
+                    newValue = newFloatValue;
+                    valueChanged = newFloatValue != serializedProperty.floatValue;
+                    break;
+
+                case SerializedPropertyType.String:
+                    delayedAttribute = PropertyUtility.GetAttribute<DelayedAttribute>(serializedProperty);
+                    MultilineAttribute multilineAttribute = PropertyUtility.GetAttribute<MultilineAttribute>(serializedProperty);
+                    TextAreaAttribute textAreaAttribute = PropertyUtility.GetAttribute<TextAreaAttribute>(serializedProperty);
+
+                    if (multilineAttribute != null) warningMessage += "MultilineAttribute is not supported by UsePropertySetterAttribute.\n\n";
+                    if (textAreaAttribute != null) warningMessage += "TextAreaAttribute is not supported by UsePropertySetterAttribute.\n\n";
+
+                    string newStringValue;
+                    if (delayedAttribute != null) newStringValue = EditorGUILayout.DelayedTextField(noLabel, serializedProperty.stringValue);
+                    else newStringValue = EditorGUILayout.TextField(noLabel, serializedProperty.stringValue);
+
+                    newValue = newStringValue;
+                    valueChanged = newStringValue != serializedProperty.stringValue;
+                    break;
+
+                case SerializedPropertyType.Color:
+                    ColorUsageAttribute colorUsageAttribute = PropertyUtility.GetAttribute<ColorUsageAttribute>(serializedProperty);
+
+                    Color newColorValue;
+                    if (colorUsageAttribute != null)
+                    {
+                        newColorValue = EditorGUILayout.ColorField(noLabel, serializedProperty.colorValue, true, 
+                            colorUsageAttribute.showAlpha, colorUsageAttribute.hdr);
+                    }
+                    else
+                    {
+                        newColorValue = EditorGUILayout.ColorField(noLabel, serializedProperty.colorValue);
+                    }
+
+                    newValue = newColorValue;
+                    valueChanged = newColorValue != serializedProperty.colorValue;
+                    break;
+
+                case SerializedPropertyType.ObjectReference:
+                    oldValue = serializedProperty.objectReferenceValue;
+                    newValue = EditorGUILayout.ObjectField(noLabel, serializedProperty.objectReferenceValue, memberType,
+                        !EditorUtility.IsPersistent(serializedProperty.serializedObject.targetObject));
+
+                    valueChanged = oldValue != newValue;
+                    break;
+
+                case SerializedPropertyType.Enum:
+                    System.Array enumValues = memberType.GetEnumValues();
+                    if (serializedProperty.enumValueIndex == -1)
+                    {
+                        warningMessage += "This enum is not supported by UsePropertySetterAttribute. Enum support is a bit iffy. Sorry.\n\n";
+                    }
+                    else
+                    {
+                        System.Enum selected = (System.Enum)enumValues.GetValue(serializedProperty.enumValueIndex);
+
+                        System.Enum newEnumValue = EditorGUILayout.EnumPopup(noLabel, selected);
+
+                        newValue = newEnumValue;
+                        //Comparing the System.Enum values directly gave false positives every frame, so we compare strings.
+                        valueChanged = newEnumValue.ToString() != selected.ToString();  
+                    }
+                    break;
+
+                case SerializedPropertyType.Vector2:
+                    Vector2 newVector2Value = EditorGUILayout.Vector2Field(noLabel, serializedProperty.vector2Value);
+
+                    newValue = newVector2Value;
+                    valueChanged = newVector2Value != serializedProperty.vector2Value;
+                    break;
+
+                case SerializedPropertyType.Vector3:
+                    Vector3 newVector3Value = EditorGUILayout.Vector3Field(noLabel, serializedProperty.vector3Value);
+
+                    newValue = newVector3Value;
+                    valueChanged = newVector3Value != serializedProperty.vector3Value;
+                    break;
+                case SerializedPropertyType.Vector4:
+                    Vector4 newVector4Value = EditorGUILayout.Vector4Field(noLabel, serializedProperty.vector4Value);
+
+                    newValue = newVector4Value;
+                    valueChanged = newVector4Value != serializedProperty.vector4Value;
+                    break;
+                case SerializedPropertyType.Rect:
+                    Rect newRectValue = EditorGUILayout.RectField(noLabel, serializedProperty.rectValue);
+
+                    newValue = newRectValue;
+                    valueChanged = newRectValue != serializedProperty.rectValue;
+                    break;
+
+                case SerializedPropertyType.AnimationCurve:
+                    AnimationCurve newAnimationCurveValue = EditorGUILayout.CurveField(noLabel, serializedProperty.animationCurveValue);
+
+                    newValue = newAnimationCurveValue;
+                    valueChanged = newAnimationCurveValue != serializedProperty.animationCurveValue;
+                    break;
+
+                case SerializedPropertyType.Bounds:
+                    Bounds newBoundsValue = EditorGUILayout.BoundsField(noLabel, serializedProperty.boundsValue);
+
+                    newValue = newBoundsValue;
+                    valueChanged = newBoundsValue != serializedProperty.boundsValue;
+                    break;
+
+                case SerializedPropertyType.Vector2Int:
+                    Vector2Int newVector2IntValue = EditorGUILayout.Vector2IntField(noLabel, serializedProperty.vector2IntValue);
+
+                    newValue = newVector2IntValue;
+                    valueChanged = newVector2IntValue != serializedProperty.vector2IntValue;
+                    break;
+
+                case SerializedPropertyType.Vector3Int:
+                    Vector3Int newVector3IntValue = EditorGUILayout.Vector3IntField(noLabel, serializedProperty.vector3IntValue);
+
+                    newValue = newVector3IntValue;
+                    valueChanged = newVector3IntValue != serializedProperty.vector3IntValue;
+                    break;
+                case SerializedPropertyType.RectInt:
+                    RectInt newRectIntValue = EditorGUILayout.RectIntField(noLabel, serializedProperty.rectIntValue);
+
+                    newValue = newRectIntValue;
+                    valueChanged = newRectIntValue.Equals(serializedProperty.rectIntValue);
+                    break;
+
+                case SerializedPropertyType.BoundsInt:
+                    BoundsInt newBoundsIntValue = EditorGUILayout.BoundsIntField(noLabel, serializedProperty.boundsIntValue);
+
+                    newValue = newBoundsIntValue;
+                    valueChanged = newBoundsIntValue != serializedProperty.boundsIntValue;
+                    break;
+
+                default:
+                    warningMessage += $"{serializedProperty.propertyType} serialized types aren't supported by UsePropertySetterAttribute. \n\n";
+                    break;
+            }
+            EditorGUILayout.EndHorizontal();
+
+            return valueChanged;
+        }
+
+        /// <summary>
+        /// Sets the value at the serialized version.
+        /// </summary>
+        private void ModifySerializedValue(SerializedProperty serializedProperty, object value)
+        {
+            //Assign the value to the serialized version in the correct way depending on each serialized type
+            switch (serializedProperty.propertyType)
+            {
+                case SerializedPropertyType.Integer:
+                    serializedProperty.intValue = (int)value;
+                    break;
+                case SerializedPropertyType.Boolean:
+                    serializedProperty.boolValue = (bool)value;
+                    break;
+                case SerializedPropertyType.Float:
+                    serializedProperty.floatValue = (float)value;
+                    break;
+                case SerializedPropertyType.String:
+                    serializedProperty.stringValue = (string)value;
+                    break;
+                case SerializedPropertyType.Color:
+                    serializedProperty.colorValue = (Color)value;
+                    break;
+                case SerializedPropertyType.ObjectReference:
+                    serializedProperty.objectReferenceValue = value as Object;
+                    break;
+                case SerializedPropertyType.LayerMask:
+                    serializedProperty.intValue = (LayerMask)value;
+                    break;
+                case SerializedPropertyType.Enum:
+                    serializedProperty.enumValueIndex = (int)value;
+                    break;
+                case SerializedPropertyType.Vector2:
+                    serializedProperty.vector2Value = (Vector2)value;
+                    break;
+                case SerializedPropertyType.Vector3:
+                    serializedProperty.vector3Value = (Vector3)value;
+                    break;
+                case SerializedPropertyType.Vector4:
+                    serializedProperty.vector4Value = (Vector4)value;
+                    break;
+                case SerializedPropertyType.Rect:
+                    serializedProperty.rectValue = (Rect)value;
+                    break;
+                case SerializedPropertyType.AnimationCurve:
+                    serializedProperty.animationCurveValue = (AnimationCurve)value;
+                    break;
+                case SerializedPropertyType.Bounds:
+                    serializedProperty.boundsValue = (Bounds)value;
+                    break;
+                case SerializedPropertyType.Vector2Int:
+                    serializedProperty.vector2IntValue = (Vector2Int)value;
+                    break;
+                case SerializedPropertyType.Vector3Int:
+                    serializedProperty.vector3IntValue = (Vector3Int)value;
+                    break;
+                case SerializedPropertyType.RectInt:
+                    serializedProperty.rectIntValue = (RectInt)value;
+                    break;
+                case SerializedPropertyType.BoundsInt:
+                    serializedProperty.boundsIntValue = (BoundsInt)value;
+                    break;
+                default:
+                    break;
+            }
+
+            //Set the object dirty so that the editor picks up the changes on the prefab
+            EditorUtility.SetDirty(serializedProperty.serializedObject.targetObject);
+        }
+
+        /// <summary>
+        /// Tries to find the member property. Not guaranteed to find one, as the given name (or auto name) could be wrong.
+        /// </summary>
+        private PropertyInfo FindProperty(SerializedProperty serializedProperty)
+        {
+            UsePropertySetterAttribute attribute = PropertyUtility.GetAttribute<UsePropertySetterAttribute>(serializedProperty);
+
+            string propertyName;
+            if (attribute.autoFindProperty) propertyName = serializedProperty.displayName.Replace(" ", string.Empty);
+            else propertyName = attribute.propertyName;
+            
+            Object targetObject = serializedProperty.serializedObject.targetObject;
+
+            return ReflectionUtility.GetProperty(targetObject, propertyName);
+        }
+
+        private FieldInfo FindField(SerializedProperty serializedProperty)
+        {
+            Object targetObject = serializedProperty.serializedObject.targetObject;
+            return ReflectionUtility.GetField(targetObject, serializedProperty.name);
+        }
+
+        //SerializedProperty.tooltip has been broken for years, so we get it manually instead.
+        private string GetPropertyTooltip(SerializedProperty serializedProperty)
+        {
+            return PropertyUtility.GetAttribute<TooltipAttribute>(serializedProperty)?.tooltip;
+        }
+    }
+}

--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/UsePropertySetterDrawer.cs.meta
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/UsePropertySetterDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: befc2cd794958504ab595c6bc5d0c50b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/NaughtyAttributes/Scripts/Test/UsePropertySetter.cs
+++ b/Assets/NaughtyAttributes/Scripts/Test/UsePropertySetter.cs
@@ -2,10 +2,17 @@
 
 namespace NaughtyAttributes.Test
 {
-    [ExecuteAlways]
     public class UsePropertySetter : MonoBehaviour
     {
-        public int MyPositiveProperty
+        public string TestString { get => _testString; set
+            {
+                print($"Previous: {_testString}, New: {value}");
+                _testString = value;
+            }
+        }
+        [SerializeField, UsePropertySetter, TextArea] private string _testString;
+
+        public float MyPositiveProperty
         {
             get => _myPositiveProperty;
             set
@@ -18,9 +25,11 @@ namespace NaughtyAttributes.Test
                 else Debug.Log("Negative! Not setting that.");
             }
         }
-        [SerializeField, UsePropertySetter, Tooltip("This is a working tooltip."), Delayed] private int _myPositiveProperty;
+        [SerializeField, UsePropertySetter("MyPositiveProperty"), Tooltip("This is a working tooltip.")]
+        private float _myPositiveProperty;
 
-        public event System.Action<int> OnNewValue;
+
+        public event System.Action<float> OnNewValue;
 
         private void OnEnable()
         {
@@ -28,7 +37,7 @@ namespace NaughtyAttributes.Test
             OnNewValue += PrintValue;
         }
 
-        private void PrintValue(int a)
+        private void PrintValue(float a)
         {
             print($"New value: {a}!");
         }

--- a/Assets/NaughtyAttributes/Scripts/Test/UsePropertySetter.cs
+++ b/Assets/NaughtyAttributes/Scripts/Test/UsePropertySetter.cs
@@ -1,0 +1,36 @@
+﻿using UnityEngine;
+
+namespace NaughtyAttributes.Test
+{
+    [ExecuteAlways]
+    public class UsePropertySetter : MonoBehaviour
+    {
+        public int MyPositiveProperty
+        {
+            get => _myPositiveProperty;
+            set
+            {
+                if (value >= 0)
+                {
+                    _myPositiveProperty = value;
+                    OnNewValue?.Invoke(value);
+                }
+                else Debug.Log("Negative! Not setting that.");
+            }
+        }
+        [SerializeField, UsePropertySetter, Tooltip("This is a working tooltip."), Delayed] private int _myPositiveProperty;
+
+        public event System.Action<int> OnNewValue;
+
+        private void OnEnable()
+        {
+            OnNewValue -= PrintValue;
+            OnNewValue += PrintValue;
+        }
+
+        private void PrintValue(int a)
+        {
+            print($"New value: {a}!");
+        }
+    }
+}

--- a/Assets/NaughtyAttributes/Scripts/Test/UsePropertySetter.cs
+++ b/Assets/NaughtyAttributes/Scripts/Test/UsePropertySetter.cs
@@ -4,13 +4,28 @@ namespace NaughtyAttributes.Test
 {
     public class UsePropertySetter : MonoBehaviour
     {
-        public string TestString { get => _testString; set
+        public bool TestBool
+        {
+            get => _testBool;
+            set
+            {
+                Debug.Log(value);
+                _testBool = value;
+            }
+        }
+        [SerializeField, UsePropertySetter] private bool _testBool;
+
+        public string TestString
+        {
+            get => _testString;
+            set
             {
                 print($"Previous: {_testString}, New: {value}");
                 _testString = value;
             }
         }
-        [SerializeField, UsePropertySetter, TextArea] private string _testString;
+        [SerializeField, UsePropertySetter, Delayed]
+        private string _testString;
 
         public float MyPositiveProperty
         {
@@ -25,7 +40,7 @@ namespace NaughtyAttributes.Test
                 else Debug.Log("Negative! Not setting that.");
             }
         }
-        [SerializeField, UsePropertySetter("MyPositiveProperty"), Tooltip("This is a working tooltip.")]
+        [SerializeField, UsePropertySetter("MyPositiveProperty"), Tooltip("This is a working tooltip."),]
         private float _myPositiveProperty;
 
 

--- a/Assets/NaughtyAttributes/Scripts/Test/UsePropertySetter.cs.meta
+++ b/Assets/NaughtyAttributes/Scripts/Test/UsePropertySetter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 27220a12cecf79e4ab3eb9a68f8b988c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
I added an attribute that goes through a property setter instead of setting the value of the field directly.
This allows one to have arbitrary reactions to the entered value, from invoking an event after setting it to outright rejecting it.

It automatically looks for a property that matches the display name of the field, and one can explicitly give the property's name instead.

Let me know if you're interested in merging it. I haven't documented it in the readme in case it doesn't get merged anyway, but I'll be happy to document it if you want.