### PR TITLE
Use "displayName" rather then "name" in Required

### DIFF
--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyValidators/RequiredPropertyValidator.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyValidators/RequiredPropertyValidator.cs
@@ -12,7 +12,7 @@ namespace NaughtyAttributes.Editor
 			{
 				if (property.objectReferenceValue == null)
 				{
-					string errorMessage = property.name + " is required";
+					string errorMessage = property.displayName + " is required";
 					if (!string.IsNullOrEmpty(requiredAttribute.Message))
 					{
 						errorMessage = requiredAttribute.Message;


### PR DESCRIPTION
The human readable version should be displayed in the error message so it matches the displayed property name.
