### PR TITLE
Make hidden properties take up no space.

### DIFF
--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/DropdownPropertyDrawer.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/DropdownPropertyDrawer.cs
@@ -10,7 +10,7 @@ namespace NaughtyAttributes.Editor
 	[CustomPropertyDrawer(typeof(DropdownAttribute))]
 	public class DropdownPropertyDrawer : PropertyDrawerBase
 	{
-		public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+		protected override float GetPropertyHeight_Internal(SerializedProperty property, GUIContent label)
 		{
 			DropdownAttribute dropdownAttribute = (DropdownAttribute) attribute;
 			object values = GetValues(property, dropdownAttribute.ValuesName);

--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/EnumFlagsPropertyDrawer.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/EnumFlagsPropertyDrawer.cs
@@ -7,7 +7,7 @@ namespace NaughtyAttributes.Editor
 	[CustomPropertyDrawer(typeof(EnumFlagsAttribute))]
 	public class EnumFlagsPropertyDrawer : PropertyDrawerBase
 	{
-		public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+		protected override float GetPropertyHeight_Internal(SerializedProperty property, GUIContent label)
 		{
 			Enum targetEnum = PropertyUtility.GetTargetObjectOfProperty(property) as Enum;
 

--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/InputAxisPropertyDrawer.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/InputAxisPropertyDrawer.cs
@@ -13,7 +13,7 @@ namespace NaughtyAttributes.Editor
 		private const string AxesPropertyPath = "m_Axes";
 		private const string NamePropertyPath = "m_Name";
 
-		public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+		protected override float GetPropertyHeight_Internal(SerializedProperty property, GUIContent label)
 		{
 			return (property.propertyType == SerializedPropertyType.String)
 				? GetPropertyHeight(property)

--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/MinMaxSliderPropertyDrawer.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/MinMaxSliderPropertyDrawer.cs
@@ -6,7 +6,7 @@ namespace NaughtyAttributes.Editor
 	[CustomPropertyDrawer(typeof(MinMaxSliderAttribute))]
 	public class MinMaxSliderPropertyDrawer : PropertyDrawerBase
 	{
-		public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+		protected override float GetPropertyHeight_Internal(SerializedProperty property, GUIContent label)
 		{
 			return (property.propertyType == SerializedPropertyType.Vector2)
 				? GetPropertyHeight(property)

--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/ProgressBarPropertyDrawer.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/ProgressBarPropertyDrawer.cs
@@ -6,7 +6,7 @@ namespace NaughtyAttributes.Editor
 	[CustomPropertyDrawer(typeof(ProgressBarAttribute))]
 	public class ProgressBarPropertyDrawer : PropertyDrawerBase
 	{
-		public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+		protected override float GetPropertyHeight_Internal(SerializedProperty property, GUIContent label)
 		{
 			return IsNumber(property)
 				? GetPropertyHeight(property)

--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/PropertyDrawerBase.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/PropertyDrawerBase.cs
@@ -37,6 +37,21 @@ namespace NaughtyAttributes.Editor
 
 		protected abstract void OnGUI_Internal(Rect rect, SerializedProperty property, GUIContent label);
 
+		sealed override public float GetPropertyHeight(SerializedProperty property, GUIContent label)
+		{
+			bool visible = PropertyUtility.IsVisible(property);
+			if (!visible)
+			{
+				return -EditorGUIUtility.standardVerticalSpacing;
+			}
+
+			return GetPropertyHeight_Internal(property, label);
+		}
+
+		protected virtual float GetPropertyHeight_Internal(SerializedProperty property, GUIContent label) {
+			return base.GetPropertyHeight(property, label);
+		}
+
 		public virtual float GetPropertyHeight(SerializedProperty property)
 		{
 			return EditorGUI.GetPropertyHeight(property, true);

--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/ReadOnlyPropertyDrawer.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/ReadOnlyPropertyDrawer.cs
@@ -6,7 +6,7 @@ namespace NaughtyAttributes.Editor
 	[CustomPropertyDrawer(typeof(ReadOnlyAttribute))]
 	public class ReadOnlyPropertyDrawer : PropertyDrawerBase
 	{
-		public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+		protected override float GetPropertyHeight_Internal(SerializedProperty property, GUIContent label)
 		{
 			return GetPropertyHeight(property);
 		}

--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/ResizableTextAreaPropertyDrawer.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/ResizableTextAreaPropertyDrawer.cs
@@ -22,7 +22,7 @@ namespace NaughtyAttributes.Editor
 			}
 		}
 
-		public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+		protected override float GetPropertyHeight_Internal(SerializedProperty property, GUIContent label)
 		{
 			return (property.propertyType == SerializedPropertyType.String)
 				? this.GetPropertyHeight(property)

--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/ScenePropertyDrawer.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/ScenePropertyDrawer.cs
@@ -14,7 +14,7 @@ namespace NaughtyAttributes.Editor
 		private const string TypeWarningMessage = "{0} must be an int or a string";
 		private const string BuildSettingsWarningMessage = "No scenes in the build settings";
 
-		public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+		protected override float GetPropertyHeight_Internal(SerializedProperty property, GUIContent label)
 		{
 			bool validPropertyType = property.propertyType == SerializedPropertyType.String || property.propertyType == SerializedPropertyType.Integer;
 			bool anySceneInBuildSettings = GetScenes().Length > 0;

--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/ShowAssetPreviewPropertyDrawer.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/ShowAssetPreviewPropertyDrawer.cs
@@ -6,7 +6,7 @@ namespace NaughtyAttributes.Editor
 	[CustomPropertyDrawer(typeof(ShowAssetPreviewAttribute))]
 	public class ShowAssetPreviewPropertyDrawer : PropertyDrawerBase
 	{
-		public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+		protected override float GetPropertyHeight_Internal(SerializedProperty property, GUIContent label)
 		{
 			if (property.propertyType == SerializedPropertyType.ObjectReference)
 			{

--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/TagPropertyDrawer.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/TagPropertyDrawer.cs
@@ -7,7 +7,7 @@ namespace NaughtyAttributes.Editor
 	[CustomPropertyDrawer(typeof(TagAttribute))]
 	public class TagPropertyDrawer : PropertyDrawerBase
 	{
-		public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+		protected override float GetPropertyHeight_Internal(SerializedProperty property, GUIContent label)
 		{
 			return (property.propertyType == SerializedPropertyType.String)
 				? GetPropertyHeight(property)


### PR DESCRIPTION
Summary: Updates PropertyDrawerBase to provide a sealed default
implementation of GetPropertyHeight that checks for that

Instead of allowing children to replace this implementation or copy
paste this logic into every child, require them to override
GetPropertyHeight_Internal, similar to how OnGUI_Internal works.

Update all children to override GetPropertyHeight_Internal instead
of GetPropertyHeight

Test Plan:
- Verified with OmniSharp that there are no C# language/syntax errors.
- Copied into my unity project and verified everything works correctly.