### PR TITLE
MetaAttribute on Buttons; Dropdown for value types.

### DIFF
--- a/Scripts/Core/DrawerAttributes/DropdownAttribute.cs
+++ b/Scripts/Core/DrawerAttributes/DropdownAttribute.cs
@@ -7,10 +7,17 @@ namespace NaughtyAttributes
 	[AttributeUsage(AttributeTargets.Field, AllowMultiple = false, Inherited = true)]
 	public class DropdownAttribute : DrawerAttribute
 	{
+		public Type ProviderType { get; private set; }
 		public string ValuesName { get; private set; }
 
 		public DropdownAttribute(string valuesName)
 		{
+			ValuesName = valuesName;
+		}
+
+		public DropdownAttribute(Type providerType, string valuesName)
+		{
+			ProviderType = providerType;
 			ValuesName = valuesName;
 		}
 	}

--- a/Scripts/Core/MetaAttributes/DisableIfAttribute.cs
+++ b/Scripts/Core/MetaAttributes/DisableIfAttribute.cs
@@ -2,7 +2,7 @@
 
 namespace NaughtyAttributes
 {
-	[AttributeUsage(AttributeTargets.Field, AllowMultiple = false, Inherited = true)]
+	[AttributeUsage(AttributeTargets.Field | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
 	public class DisableIfAttribute : EnableIfAttributeBase
 	{
 		public DisableIfAttribute(string condition)

--- a/Scripts/Core/MetaAttributes/EnableIfAttribute.cs
+++ b/Scripts/Core/MetaAttributes/EnableIfAttribute.cs
@@ -2,7 +2,7 @@
 
 namespace NaughtyAttributes
 {
-	[AttributeUsage(AttributeTargets.Field, AllowMultiple = false, Inherited = true)]
+	[AttributeUsage(AttributeTargets.Field | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
 	public class EnableIfAttribute : EnableIfAttributeBase
 	{
 		public EnableIfAttribute(string condition)

--- a/Scripts/Core/MetaAttributes/HideIfAttribute.cs
+++ b/Scripts/Core/MetaAttributes/HideIfAttribute.cs
@@ -2,7 +2,7 @@
 
 namespace NaughtyAttributes
 {
-	[AttributeUsage(AttributeTargets.Field, AllowMultiple = false, Inherited = true)]
+	[AttributeUsage(AttributeTargets.Field | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
 	public class HideIfAttribute : ShowIfAttributeBase
 	{
 		public HideIfAttribute(string condition)

--- a/Scripts/Core/MetaAttributes/ShowIfAttribute.cs
+++ b/Scripts/Core/MetaAttributes/ShowIfAttribute.cs
@@ -2,7 +2,7 @@
 
 namespace NaughtyAttributes
 {
-	[AttributeUsage(AttributeTargets.Field, AllowMultiple = false, Inherited = true)]
+	[AttributeUsage(AttributeTargets.Field | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
 	public class ShowIfAttribute : ShowIfAttributeBase
 	{
 		public ShowIfAttribute(string condition)

--- a/Scripts/Editor/NaughtyInspector.cs
+++ b/Scripts/Editor/NaughtyInspector.cs
@@ -15,7 +15,7 @@ namespace NaughtyAttributes.Editor
 		private IEnumerable<PropertyInfo> _nativeProperties;
 		private IEnumerable<MethodInfo> _methods;
 
-		private void OnEnable()
+		protected virtual void OnEnable()
 		{
 			_nonSerializedFields = ReflectionUtility.GetAllFields(
 				target, f => f.GetCustomAttributes(typeof(ShowNonSerializedFieldAttribute), true).Length > 0);
@@ -27,7 +27,7 @@ namespace NaughtyAttributes.Editor
 				target, m => m.GetCustomAttributes(typeof(ButtonAttribute), true).Length > 0);
 		}
 
-		private void OnDisable()
+		protected virtual void OnDisable()
 		{
 			ReorderableListPropertyDrawer.Instance.ClearCache();
 		}
@@ -67,7 +67,7 @@ namespace NaughtyAttributes.Editor
 			}
 		}
 
-		private void DrawSerializedProperties()
+		protected void DrawSerializedProperties()
 		{
 			serializedObject.Update();
 
@@ -107,7 +107,7 @@ namespace NaughtyAttributes.Editor
 			serializedObject.ApplyModifiedProperties();
 		}
 
-		private void DrawNonSerializedFields()
+		protected void DrawNonSerializedFields()
 		{
 			if (_nonSerializedFields.Any())
 			{
@@ -123,7 +123,7 @@ namespace NaughtyAttributes.Editor
 			}
 		}
 
-		private void DrawNativeProperties()
+		protected void DrawNativeProperties()
 		{
 			if (_nativeProperties.Any())
 			{
@@ -139,7 +139,7 @@ namespace NaughtyAttributes.Editor
 			}
 		}
 
-		private void DrawButtons()
+		protected void DrawButtons()
 		{
 			if (_methods.Any(m => ButtonUtility.IsVisible(serializedObject.targetObject, m)))
 			{

--- a/Scripts/Editor/NaughtyInspector.cs
+++ b/Scripts/Editor/NaughtyInspector.cs
@@ -141,7 +141,7 @@ namespace NaughtyAttributes.Editor
 
 		private void DrawButtons()
 		{
-			if (_methods.Any())
+			if (_methods.Any(m => ButtonUtility.IsVisible(serializedObject.targetObject, m)))
 			{
 				EditorGUILayout.Space();
 				EditorGUILayout.LabelField("Buttons", GetHeaderGUIStyle());

--- a/Scripts/Editor/NaughtyInspector.cs
+++ b/Scripts/Editor/NaughtyInspector.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using UnityEditor;
@@ -17,14 +18,15 @@ namespace NaughtyAttributes.Editor
 
 		protected virtual void OnEnable()
 		{
+			Type targetType = target.GetType();
 			_nonSerializedFields = ReflectionUtility.GetAllFields(
-				target, f => f.GetCustomAttributes(typeof(ShowNonSerializedFieldAttribute), true).Length > 0);
+				targetType, f => f.GetCustomAttributes(typeof(ShowNonSerializedFieldAttribute), true).Length > 0);
 
 			_nativeProperties = ReflectionUtility.GetAllProperties(
-				target, p => p.GetCustomAttributes(typeof(ShowNativePropertyAttribute), true).Length > 0);
+				targetType, p => p.GetCustomAttributes(typeof(ShowNativePropertyAttribute), true).Length > 0);
 
 			_methods = ReflectionUtility.GetAllMethods(
-				target, m => m.GetCustomAttributes(typeof(ButtonAttribute), true).Length > 0);
+				targetType, m => m.GetCustomAttributes(typeof(ButtonAttribute), true).Length > 0);
 		}
 
 		protected virtual void OnDisable()

--- a/Scripts/Editor/PropertyDrawers/DropdownPropertyDrawer.cs
+++ b/Scripts/Editor/PropertyDrawers/DropdownPropertyDrawer.cs
@@ -81,7 +81,7 @@ namespace NaughtyAttributes.Editor
 							index++;
 
 							KeyValuePair<string, object> current = dropdownEnumerator.Current;
-							if (current.Value.Equals(selectedValue))
+							if (EqualityComparer<object>.Default.Equals(current.Value, selectedValue))
 							{
 								selectedValueIndex = index;
 							}

--- a/Scripts/Editor/PropertyDrawers/DropdownPropertyDrawer.cs
+++ b/Scripts/Editor/PropertyDrawers/DropdownPropertyDrawer.cs
@@ -84,7 +84,7 @@ namespace NaughtyAttributes.Editor
 							index++;
 
 							KeyValuePair<string, object> current = dropdownEnumerator.Current;
-							if (EqualityComparer<object>.Default.Equals(current.Value, selectedValue))
+							if (!string.IsNullOrEmpty(current.Key) && EqualityComparer<object>.Default.Equals(current.Value, selectedValue))
 							{
 								selectedValueIndex = index;
 							}

--- a/Scripts/Editor/PropertyDrawers/DropdownPropertyDrawer.cs
+++ b/Scripts/Editor/PropertyDrawers/DropdownPropertyDrawer.cs
@@ -60,7 +60,7 @@ namespace NaughtyAttributes.Editor
 					}
 
 					NaughtyEditorGUI.Dropdown(
-						rect, property.serializedObject, target, dropdownField, label.text, selectedValueIndex, values, displayOptions);
+						rect, property, label.text, selectedValueIndex, values, displayOptions);
 				}
 				else if (valuesObject is IDropdownList)
 				{
@@ -97,7 +97,7 @@ namespace NaughtyAttributes.Editor
 					}
 
 					NaughtyEditorGUI.Dropdown(
-						rect, property.serializedObject, target, dropdownField, label.text, selectedValueIndex, values.ToArray(), displayOptions.ToArray());
+						rect, property, label.text, selectedValueIndex, values.ToArray(), displayOptions.ToArray());
 				}
 			}
 			else

--- a/Scripts/Editor/PropertyValidators/ValidateInputPropertyValidator.cs
+++ b/Scripts/Editor/PropertyValidators/ValidateInputPropertyValidator.cs
@@ -10,14 +10,15 @@ namespace NaughtyAttributes.Editor
 		{
 			ValidateInputAttribute validateInputAttribute = PropertyUtility.GetAttribute<ValidateInputAttribute>(property);
 			object target = PropertyUtility.GetTargetObjectWithProperty(property);
+			Type targetType = target.GetType();
 
-			MethodInfo validationCallback = ReflectionUtility.GetMethod(target, validateInputAttribute.CallbackName);
+			MethodInfo validationCallback = ReflectionUtility.GetMethod(targetType, validateInputAttribute.CallbackName);
 
 			if (validationCallback != null &&
 				validationCallback.ReturnType == typeof(bool) &&
 				validationCallback.GetParameters().Length == 1)
 			{
-				FieldInfo fieldInfo = ReflectionUtility.GetField(target, property.name);
+				FieldInfo fieldInfo = ReflectionUtility.GetField(targetType, property.name);
 				Type fieldType = fieldInfo.FieldType;
 				Type parameterType = validationCallback.GetParameters()[0].ParameterType;
 

--- a/Scripts/Editor/Utility/ButtonUtility.cs
+++ b/Scripts/Editor/Utility/ButtonUtility.cs
@@ -1,0 +1,57 @@
+﻿using UnityEditor;
+using System.Reflection;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace NaughtyAttributes.Editor
+{
+	public static class ButtonUtility
+	{
+		public static bool IsEnabled(Object target, MethodInfo method)
+		{
+			EnableIfAttributeBase enableIfAttribute = method.GetCustomAttribute<EnableIfAttributeBase>();
+			if (enableIfAttribute == null)
+			{
+				return true;
+			}
+
+			List<bool> conditionValues = PropertyUtility.GetConditionValues(target, enableIfAttribute.Conditions);
+			if (conditionValues.Count > 0)
+			{
+				bool enabled = PropertyUtility.GetConditionsFlag(conditionValues, enableIfAttribute.ConditionOperator, enableIfAttribute.Inverted);
+				return enabled;
+			}
+			else
+			{
+				string message = enableIfAttribute.GetType().Name + " needs a valid boolean condition field, property or method name to work";
+				Debug.LogWarning(message, target);
+
+				return false;
+			}
+		}
+
+		public static bool IsVisible(Object target, MethodInfo method)
+		{
+			ShowIfAttributeBase showIfAttribute = method.GetCustomAttribute<ShowIfAttributeBase>();
+			if (showIfAttribute == null)
+			{
+				return true;
+			}
+
+			List<bool> conditionValues = PropertyUtility.GetConditionValues(target, showIfAttribute.Conditions);
+			if (conditionValues.Count > 0)
+			{
+				bool enabled = PropertyUtility.GetConditionsFlag(conditionValues, showIfAttribute.ConditionOperator, showIfAttribute.Inverted);
+				return enabled;
+			}
+			else
+			{
+				string message = showIfAttribute.GetType().Name + " needs a valid boolean condition field, property or method name to work";
+				Debug.LogWarning(message, target);
+
+				return false;
+			}
+		}
+	}
+}

--- a/Scripts/Editor/Utility/ButtonUtility.cs.meta
+++ b/Scripts/Editor/Utility/ButtonUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c2f9ce73798d21b40a2bdbf1a0483073
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Editor/Utility/NaughtyEditorGUI.cs
+++ b/Scripts/Editor/Utility/NaughtyEditorGUI.cs
@@ -115,11 +115,19 @@ namespace NaughtyAttributes.Editor
 
 		public static void Button(UnityEngine.Object target, MethodInfo methodInfo)
 		{
+			bool visible = ButtonUtility.IsVisible(target, methodInfo);
+			if (!visible)
+			{
+				return;
+			}
+			
 			if (methodInfo.GetParameters().Length == 0)
 			{
 				ButtonAttribute buttonAttribute = (ButtonAttribute)methodInfo.GetCustomAttributes(typeof(ButtonAttribute), true)[0];
 				string buttonText = string.IsNullOrEmpty(buttonAttribute.Text) ? methodInfo.Name : buttonAttribute.Text;
 
+				bool enabled = ButtonUtility.IsEnabled(target, methodInfo);
+				GUI.enabled = enabled;
 				if (GUILayout.Button(buttonText))
 				{
 					methodInfo.Invoke(target, null);
@@ -142,6 +150,7 @@ namespace NaughtyAttributes.Editor
 						}
 					}
 				}
+				GUI.enabled = true;
 			}
 			else
 			{

--- a/Scripts/Editor/Utility/NaughtyEditorGUI.cs
+++ b/Scripts/Editor/Utility/NaughtyEditorGUI.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using UnityEditor;
@@ -88,16 +89,14 @@ namespace NaughtyAttributes.Editor
 		/// Creates a dropdown
 		/// </summary>
 		/// <param name="rect">The rect the defines the position and size of the dropdown in the inspector</param>
-		/// <param name="serializedObject">The serialized object that is being updated</param>
-		/// <param name="target">The target object that contains the dropdown</param>
-		/// <param name="dropdownField">The field of the target object that holds the currently selected dropdown value</param>
+		/// <param name="property">The serialized property that is being updated</param>
 		/// <param name="label">The label of the dropdown</param>
 		/// <param name="selectedValueIndex">The index of the value from the values array</param>
 		/// <param name="values">The values of the dropdown</param>
 		/// <param name="displayOptions">The display options for the values</param>
 		public static void Dropdown(
-			Rect rect, SerializedObject serializedObject, object target, FieldInfo dropdownField,
-			string label, int selectedValueIndex, object[] values, string[] displayOptions)
+			Rect rect, SerializedProperty property, string label, 
+			int selectedValueIndex, object[] values, string[] displayOptions)
 		{
 			EditorGUI.BeginChangeCheck();
 
@@ -105,11 +104,8 @@ namespace NaughtyAttributes.Editor
 
 			if (EditorGUI.EndChangeCheck())
 			{
-				Undo.RecordObject(serializedObject.targetObject, "Dropdown");
-
-				// TODO: Problem with structs, because they are value type.
-				// The solution is to make boxing/unboxing but unfortunately I don't know the compile time type of the target object
-				dropdownField.SetValue(target, values[newIndex]);
+				Undo.RecordObject(property.serializedObject.targetObject, "Dropdown");
+				PropertyUtility.SetValue(property, values[newIndex]);
 			}
 		}
 

--- a/Scripts/Editor/Utility/PropertyUtility.cs
+++ b/Scripts/Editor/Utility/PropertyUtility.cs
@@ -129,7 +129,7 @@ namespace NaughtyAttributes.Editor
 			}
 		}
 
-		private static List<bool> GetConditionValues(object target, string[] conditions)
+		internal static List<bool> GetConditionValues(object target, string[] conditions)
 		{
 			List<bool> conditionValues = new List<bool>();
 			foreach (var condition in conditions)
@@ -160,7 +160,7 @@ namespace NaughtyAttributes.Editor
 			return conditionValues;
 		}
 
-		private static bool GetConditionsFlag(List<bool> conditionValues, EConditionOperator conditionOperator, bool invert)
+		internal static bool GetConditionsFlag(List<bool> conditionValues, EConditionOperator conditionOperator, bool invert)
 		{
 			bool flag;
 			if (conditionOperator == EConditionOperator.And)

--- a/Scripts/Editor/Utility/ReflectionUtility.cs
+++ b/Scripts/Editor/Utility/ReflectionUtility.cs
@@ -7,11 +7,11 @@ namespace NaughtyAttributes.Editor
 {
 	public static class ReflectionUtility
 	{
-		public static IEnumerable<FieldInfo> GetAllFields(object target, Func<FieldInfo, bool> predicate)
+		public static IEnumerable<FieldInfo> GetAllFields(Type type, Func<FieldInfo, bool> predicate)
 		{
 			List<Type> types = new List<Type>()
 			{
-				target.GetType()
+				type
 			};
 
 			while (types.Last().BaseType != null)
@@ -32,11 +32,11 @@ namespace NaughtyAttributes.Editor
 			}
 		}
 
-		public static IEnumerable<PropertyInfo> GetAllProperties(object target, Func<PropertyInfo, bool> predicate)
+		public static IEnumerable<PropertyInfo> GetAllProperties(Type type, Func<PropertyInfo, bool> predicate)
 		{
 			List<Type> types = new List<Type>()
 			{
-				target.GetType()
+				type
 			};
 
 			while (types.Last().BaseType != null)
@@ -57,28 +57,28 @@ namespace NaughtyAttributes.Editor
 			}
 		}
 
-		public static IEnumerable<MethodInfo> GetAllMethods(object target, Func<MethodInfo, bool> predicate)
+		public static IEnumerable<MethodInfo> GetAllMethods(Type type, Func<MethodInfo, bool> predicate)
 		{
-			IEnumerable<MethodInfo> methodInfos = target.GetType()
+			IEnumerable<MethodInfo> methodInfos = type
 				.GetMethods(BindingFlags.Instance | BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public)
 				.Where(predicate);
 
 			return methodInfos;
 		}
 
-		public static FieldInfo GetField(object target, string fieldName)
+		public static FieldInfo GetField(Type type, string fieldName)
 		{
-			return GetAllFields(target, f => f.Name.Equals(fieldName, StringComparison.InvariantCulture)).FirstOrDefault();
+			return GetAllFields(type, f => f.Name.Equals(fieldName, StringComparison.InvariantCulture)).FirstOrDefault();
 		}
 
-		public static PropertyInfo GetProperty(object target, string propertyName)
+		public static PropertyInfo GetProperty(Type type, string propertyName)
 		{
-			return GetAllProperties(target, p => p.Name.Equals(propertyName, StringComparison.InvariantCulture)).FirstOrDefault();
+			return GetAllProperties(type, p => p.Name.Equals(propertyName, StringComparison.InvariantCulture)).FirstOrDefault();
 		}
 
-		public static MethodInfo GetMethod(object target, string methodName)
+		public static MethodInfo GetMethod(Type type, string methodName)
 		{
-			return GetAllMethods(target, m => m.Name.Equals(methodName, StringComparison.InvariantCulture)).FirstOrDefault();
+			return GetAllMethods(type, m => m.Name.Equals(methodName, StringComparison.InvariantCulture)).FirstOrDefault();
 		}
 	}
 }

--- a/Scripts/Test/DropdownTest.cs
+++ b/Scripts/Test/DropdownTest.cs
@@ -5,6 +5,236 @@ namespace NaughtyAttributes.Test
 {
 	public class DropdownTest : MonoBehaviour
 	{
+		        [System.Flags]
+        public enum FlagsEnum
+        {
+            A = 0,
+            B = 1,
+            C = 2,
+            D = 4,
+            E = C | D,
+        }
+
+        [System.Serializable]
+        public struct MegaValueType : System.IEquatable<MegaValueType>
+        {
+            public int[] arrayValue;
+            public int intValue;
+            public LayerMask layerMaskValue;
+            public char charValue;
+            public bool boolValue;
+            public float floatValue;
+            public string stringValue;
+            public Color colorValue;
+            public GameObject objectReferenceValue;
+            public FlagsEnum enumValue;
+            public Vector2 vector2Value;
+            public Vector3 vector3Value;
+            public Vector4 vector4Value;
+            public Rect rectValue;
+            public AnimationCurve animationCurveValue;
+            public Bounds boundsValue;
+            public Quaternion quaternionValue;
+            public ExposedReference<GameObject> exposedReferenceValue;
+            public Vector2Int vector2IntValue;
+            public Vector3Int vector3IntValue;
+            public RectInt rectIntValue;
+            public BoundsInt boundsIntValue;
+            public Gradient gradientValue;
+            public NestedValueType genericValue;
+
+
+            public bool Equals(MegaValueType other)
+            {
+                return intValue == other.intValue
+                       && ((int) layerMaskValue).Equals(other.layerMaskValue)
+                       && charValue == other.charValue
+                       && boolValue == other.boolValue
+                       && floatValue.Equals(other.floatValue)
+                       && stringValue == other.stringValue
+                       && colorValue.Equals(other.colorValue)
+                       && Equals(objectReferenceValue, other.objectReferenceValue)
+                       && enumValue == other.enumValue
+                       && vector2Value.Equals(other.vector2Value)
+                       && vector3Value.Equals(other.vector3Value)
+                       && vector4Value.Equals(other.vector4Value)
+                       && rectValue.Equals(other.rectValue)
+                       && Equals(animationCurveValue, other.animationCurveValue)
+                       && boundsValue.Equals(other.boundsValue)
+                       && quaternionValue.Equals(other.quaternionValue)
+                       && exposedReferenceValue.Equals(other.exposedReferenceValue)
+                       && vector2IntValue.Equals(other.vector2IntValue)
+                       && vector3IntValue.Equals(other.vector3IntValue)
+                       && rectIntValue.Equals(other.rectIntValue)
+                       && boundsIntValue.Equals(other.boundsIntValue)
+                       && Equals(gradientValue, other.gradientValue)
+                       && genericValue.Equals(other.genericValue)
+                    ;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is MegaValueType other && Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    int hashCode = intValue;
+                    hashCode = (hashCode * 397) ^ layerMaskValue.GetHashCode();
+                    hashCode = (hashCode * 397) ^ charValue.GetHashCode();
+                    hashCode = (hashCode * 397) ^ boolValue.GetHashCode();
+                    hashCode = (hashCode * 397) ^ floatValue.GetHashCode();
+                    hashCode = (hashCode * 397) ^ (stringValue != null ? stringValue.GetHashCode() : 0);
+                    hashCode = (hashCode * 397) ^ colorValue.GetHashCode();
+                    hashCode = (hashCode * 397) ^
+                               (objectReferenceValue != null ? objectReferenceValue.GetHashCode() : 0);
+                    hashCode = (hashCode * 397) ^ (int) enumValue;
+                    hashCode = (hashCode * 397) ^ vector2Value.GetHashCode();
+                    hashCode = (hashCode * 397) ^ vector3Value.GetHashCode();
+                    hashCode = (hashCode * 397) ^ vector4Value.GetHashCode();
+                    hashCode = (hashCode * 397) ^ rectValue.GetHashCode();
+                    hashCode = (hashCode * 397) ^ (animationCurveValue != null ? animationCurveValue.GetHashCode() : 0);
+                    hashCode = (hashCode * 397) ^ boundsValue.GetHashCode();
+                    hashCode = (hashCode * 397) ^ quaternionValue.GetHashCode();
+                    hashCode = (hashCode * 397) ^ exposedReferenceValue.GetHashCode();
+                    hashCode = (hashCode * 397) ^ vector2IntValue.GetHashCode();
+                    hashCode = (hashCode * 397) ^ vector3IntValue.GetHashCode();
+                    hashCode = (hashCode * 397) ^ rectIntValue.GetHashCode();
+                    hashCode = (hashCode * 397) ^ boundsIntValue.GetHashCode();
+                    hashCode = (hashCode * 397) ^ (gradientValue != null ? gradientValue.GetHashCode() : 0);
+                    hashCode = (hashCode * 397) ^ genericValue.GetHashCode();
+                    return hashCode;
+                }
+            }
+        }
+
+        [System.Serializable]
+        public struct NestedValueType : System.IEquatable<NestedValueType>
+        {
+            public int intValue;
+            public LayerMask layerMaskValue;
+            public AnimationCurve animationCurveValue;
+            public Vector2Int vector2IntValue;
+
+            public bool Equals(NestedValueType other)
+            {
+                return intValue == other.intValue
+                       && layerMaskValue.Equals(other.layerMaskValue)
+                       && Equals(animationCurveValue, other.animationCurveValue)
+                       && vector2IntValue.Equals(other.vector2IntValue);
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is NestedValueType other && Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    int hashCode = intValue;
+                    hashCode = (hashCode * 397) ^ layerMaskValue.GetHashCode();
+                    hashCode = (hashCode * 397) ^ (animationCurveValue != null ? animationCurveValue.GetHashCode() : 0);
+                    hashCode = (hashCode * 397) ^ vector2IntValue.GetHashCode();
+                    return hashCode;
+                }
+            }
+        }
+
+        public DropdownList<MegaValueType> GetValueTypes()
+        {
+            return new DropdownList<MegaValueType>
+            {
+                {
+                    "Zero",
+                    new MegaValueType
+                    {
+                        arrayValue = new []{ 0 },
+                        intValue = 0,
+                        layerMaskValue = 0,
+                        charValue = 'a',
+                        boolValue = false,
+                        floatValue = 0,
+                        stringValue = "a",
+                        colorValue = Color.red,
+                        objectReferenceValue = null,
+                        enumValue = FlagsEnum.A | FlagsEnum.B,
+                        vector2Value = Vector2.zero,
+                        vector3Value = Vector3.zero,
+                        vector4Value = Vector4.zero,
+                        rectValue = Rect.zero,
+                        animationCurveValue = AnimationCurve.EaseInOut(0, 0, 1, 1),
+                        boundsValue = new Bounds(Vector3.zero, Vector3.zero),
+                        quaternionValue = Quaternion.identity,
+                        exposedReferenceValue = new ExposedReference<GameObject>(),
+                        vector2IntValue = Vector2Int.zero,
+                        vector3IntValue = Vector3Int.zero,
+                        rectIntValue = new RectInt(Vector2Int.zero, Vector2Int.zero),
+                        boundsIntValue = new BoundsInt(Vector3Int.zero, Vector3Int.zero),
+                        gradientValue = new Gradient(),
+                        genericValue = new NestedValueType
+                        {
+                            intValue = 0,
+                            animationCurveValue = AnimationCurve.EaseInOut(0, 0, 1, 1),
+                            layerMaskValue = 0,
+                            vector2IntValue = Vector2Int.zero,
+                        }
+                    }
+                },
+
+                {
+                    "One",
+                    new MegaValueType
+                    {
+                        arrayValue = new []{ 1, 1 },
+                        intValue = 1,
+                        layerMaskValue = 1,
+                        charValue = 'b',
+                        boolValue = true,
+                        floatValue = 1,
+                        stringValue = "b",
+                        colorValue = Color.green,
+                        objectReferenceValue = gameObject,
+                        enumValue = FlagsEnum.C | FlagsEnum.D,
+                        vector2Value = Vector2.one,
+                        vector3Value = Vector3.one,
+                        vector4Value = Vector4.one,
+                        rectValue = new Rect(Vector2.one, Vector2.one),
+                        animationCurveValue = AnimationCurve.EaseInOut(0, 1, 1, 0),
+                        boundsValue = new Bounds(Vector3.one, Vector3.one),
+                        quaternionValue = Quaternion.Euler(90, 90, 90),
+                        exposedReferenceValue = new ExposedReference<GameObject>{ defaultValue = gameObject },
+                        vector2IntValue = Vector2Int.one,
+                        vector3IntValue = Vector3Int.one,
+                        rectIntValue = new RectInt(Vector2Int.one, Vector2Int.one),
+                        boundsIntValue = new BoundsInt(Vector3Int.one, Vector3Int.one),
+                        gradientValue = new Gradient(),
+                        genericValue = new NestedValueType
+                        {
+                            intValue = 1,
+                            animationCurveValue = AnimationCurve.EaseInOut(0, 1, 1, 0),
+                            layerMaskValue = 1,
+                            vector2IntValue = Vector2Int.one,
+                        }
+                    }
+                }
+            };
+        }
+
+        [Dropdown(nameof(GetValueTypes))]
+        [OnValueChanged(nameof(OnValueChangedCallback))]
+        public MegaValueType valueType;
+
+        private void OnValueChangedCallback(MegaValueType oldValue, MegaValueType newValue)
+        {
+            copyType = valueType;
+        }
+
+        public MegaValueType copyType;
+		
 		[Dropdown("intValues")]
 		public int intValue;
 


### PR DESCRIPTION
### MetaAttribute on Buttons
Added support for meta attributes on buttons following the existing behavior for serialized properties. 

```csharp
[Button]
[ShowIf(nameof(isPaused))]
public void ResumeDialogue() { /*...*/ }
```

### Optional parameters on Buttons
Methods with all optional parameters can now be annotated with the Button attribute. 
The method will be invoked with the default parameters values.
 
### Use Buttons on Coroutines
As per the feature request #151, Button attributes placed on methods that return IEnumerator on MonoBehaviours will now start a coroutine on the target object if the game is playing.

### Null Values on DropdownLists
Currently, we will run into a NullReferenceException if a DropdownList contains a null value. I fixed this issue on this pull request. The following example will run with no problems:
```csharp
private DropdownList<string> GetStringValues()
{
	return new DropdownList<Vector3>()
	{
		{ "<empty>,   null }, // <-- NullReferenceException  
		{ "Pause",   "pause" },
		{ "Action",    "action" },
		{ "Stop",      "stop" },
		{ "Resume",    "resume" },
	};
}
```

### Dropdown for value types
Added Dropdown support on value types. Instead of setting the property value using FieldInfo the value is now set using SerializedProperty API. The following code will now work as intended:
```csharp
[Serializable]
public struct ValueType, IEquatable<ValueType>
{
    public int myField;
    public GameObject myObject;

    // ... IEquatable implementation
}

[Dropdown(...)]
public ValueType myValue;
```

There is a catch though, AnimationCurve or Gradient properties are not being set properly. I am not sure why this is happening this bug was happening even before my commits.



