### PR TITLE
add: OnEnabled OnDisabled virtual methods

### DIFF
--- a/Assets/NaughtyAttributes/Scripts/Editor/NaughtyInspector.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/NaughtyInspector.cs
@@ -25,12 +25,17 @@ namespace NaughtyAttributes.Editor
 
 			_methods = ReflectionUtility.GetAllMethods(
 				target, m => m.GetCustomAttributes(typeof(ButtonAttribute), true).Length > 0);
+			OnEnabled();
 		}
 
 		private void OnDisable()
 		{
 			ReorderableListPropertyDrawer.Instance.ClearCache();
+			OnDisabled();
 		}
+
+		protected virtual void OnEnabled() { }
+		protected virtual void OnDisabled() { }
 
 		public override void OnInspectorGUI()
 		{


### PR DESCRIPTION
@garrafote were right at [this PR](https://github.com/dbrizov/NaughtyAttributes/pull/155)

### The problem:

We need a way to inherit NaughtyInspector and still be able to get OnEnable() and OnDisable() calls.

### First non working approachs:

- make the methods protected to be able to implement them but call base.OnEnable/Disable() to make the base inspector work.
- mark the methods as virtual to be able to override them but still being able to call base.OnEnable/Disable() to make the base inspector work

None of these solutions work, as Unity is only calling the base class methods

I wonder why it behaves of this way in UnityEditor classes, as in MonoBehaviour classes it always calls the base class methods, as it is calling them by reflection and it traverses the class hierarchy from bottom to top (as I understand)

### My solution

I have added two virtual methods to NaughtyInspector class:  OnEnabled() and OnDisabled()

By default they don't do anything, but they can be overridden to change the default idle behaviour and maje make something happen.

The are called at the end of OnEnable and OnDisable methods (that's why they are called OnEnabled and OnDisabled)
