### PR TITLE
Type support for ShowNativeProperty

### DIFF
--- a/Assets/NaughtyAttributes/Scripts/Editor/Utility/NaughtyEditorGUI.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/Utility/NaughtyEditorGUI.cs
@@ -301,6 +301,10 @@ namespace NaughtyAttributes.Editor
 			{
 				EditorGUILayout.EnumPopup(label, (Enum)value);
 			}
+			else if (valueType.BaseType == typeof(System.Reflection.TypeInfo))
+			{
+				EditorGUILayout.TextField(label, value.ToString());
+			}
 			else
 			{
 				isDrawn = false;


### PR DESCRIPTION
This tiny fix adds "Type" type support to [ShowNativeProperty] attribute (allows displaying class name for Type fields marked with [ShowNativeProperty] attribute).