### PR TITLE
#161 fix, drag+drop handling on reorderable list header

### DIFF
--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers_SpecialCase/ReorderableListPropertyDrawer.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers_SpecialCase/ReorderableListPropertyDrawer.cs
@@ -24,11 +24,13 @@ namespace NaughtyAttributes.Editor
 
 				if (!_reorderableListsByPropertyName.ContainsKey(key))
 				{
-					ReorderableList reorderableList = new ReorderableList(property.serializedObject, property, true, true, true, true)
+					ReorderableList reorderableList = null;
+					reorderableList = new ReorderableList(property.serializedObject, property, true, true, true, true)
 					{
 						drawHeaderCallback = (Rect rect) =>
 						{
 							EditorGUI.LabelField(rect, string.Format("{0}: {1}", label.text, property.arraySize), EditorStyles.boldLabel);
+							HandleDragAndDrop(rect, reorderableList);
 						},
 
 						drawElementCallback = (Rect rect, int index, bool isActive, bool isFocused) =>
@@ -38,7 +40,7 @@ namespace NaughtyAttributes.Editor
 							rect.x += 10.0f;
 							rect.width -= 10.0f;
 
-							EditorGUI.PropertyField(new Rect(rect.x, rect.y, rect.width, 0.0f), element, true);
+							EditorGUI.PropertyField(new Rect(rect.x, rect.y, rect.width, EditorGUI.GetPropertyHeight(property.GetArrayElementAtIndex(index))), element, true);
 						},
 
 						elementHeightCallback = (int index) =>
@@ -57,6 +59,63 @@ namespace NaughtyAttributes.Editor
 				string message = typeof(ReorderableListAttribute).Name + " can be used only on arrays or lists";
 				NaughtyEditorGUI.HelpBox_Layout(message, MessageType.Warning, context: property.serializedObject.targetObject);
 				EditorGUILayout.PropertyField(property, true);
+			}
+		}
+		private bool IsAssignable(Object obj, ReorderableList list)
+		{
+			System.Type type = ReflectionUtility.GetType(list.serializedProperty);
+			type = ReflectionUtility.IfListGetInnerTypeOfList(type);
+			return type.IsAssignableFrom(obj.GetType());
+		}
+
+		private void HandleDragAndDrop(Rect rect, ReorderableList list)
+		{
+			var currentEvent = Event.current;
+			var usedEvent = false;
+			;
+			switch (currentEvent.type)
+			{
+				case EventType.DragExited:
+					if (GUI.enabled)
+						HandleUtility.Repaint();
+					break;
+
+				case EventType.DragUpdated:
+				case EventType.DragPerform:
+					if (rect.Contains(currentEvent.mousePosition) && GUI.enabled)
+					{
+						// Check each single object, so we can add multiple objects in a single drag.
+						bool didAcceptDrag = false;
+						Object[] references = DragAndDrop.objectReferences;
+						foreach (Object obj in references)
+						{
+							if (IsAssignable(obj, list))
+							{
+								DragAndDrop.visualMode = DragAndDropVisualMode.Copy;
+								if (currentEvent.type == EventType.DragPerform)
+								{
+									list.serializedProperty.arraySize++;
+									int arrayEnd = list.serializedProperty.arraySize - 1;
+									list.serializedProperty.GetArrayElementAtIndex(arrayEnd).objectReferenceValue = obj;
+									didAcceptDrag = true;
+								}
+							}
+						}
+						if (didAcceptDrag)
+						{
+							GUI.changed = true;
+							DragAndDrop.AcceptDrag();
+							usedEvent = true;
+						}
+					}
+					break;
+				case EventType.ValidateCommand:
+				case EventType.ExecuteCommand:
+					break;
+			}
+			if (usedEvent)
+			{
+				currentEvent.Use();
 			}
 		}
 

--- a/Assets/NaughtyAttributes/Scripts/Editor/Utility/ReflectionUtility.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/Utility/ReflectionUtility.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using UnityEditor;
 
 namespace NaughtyAttributes.Editor
 {
@@ -9,6 +10,8 @@ namespace NaughtyAttributes.Editor
 	{
 		public static IEnumerable<FieldInfo> GetAllFields(object target, Func<FieldInfo, bool> predicate)
 		{
+			if (target == null) yield break;
+
 			List<Type> types = new List<Type>()
 			{
 				target.GetType()
@@ -79,6 +82,27 @@ namespace NaughtyAttributes.Editor
 		public static MethodInfo GetMethod(object target, string methodName)
 		{
 			return GetAllMethods(target, m => m.Name.Equals(methodName, StringComparison.InvariantCulture)).FirstOrDefault();
+		}
+		public static Type GetType(SerializedProperty property)
+		{
+			Type parentType = property.serializedObject.targetObject.GetType();
+			FieldInfo fi = parentType.GetField(property.propertyPath, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+			return fi.FieldType;
+		}
+
+		public static Type IfListGetInnerTypeOfList(System.Type listType)
+		{
+			foreach (Type interfaceType in listType.GetInterfaces())
+			{
+				if (interfaceType.IsGenericType &&
+					interfaceType.GetGenericTypeDefinition()
+					== typeof(IList<>))
+				{
+					Type itemType = interfaceType.GetGenericArguments()[0];
+					return itemType;
+				}
+			}
+			return listType;
 		}
 	}
 }


### PR DESCRIPTION
-Partial fix for #161, null ref when viewing gameobject with null script.  Not displaying the usually missing script unity warning, but no longer throwing a null ref.
-Addition of drag + drop handling on the reorderable list header the way unity lists supports
-Fix for custom type propertydrawers not rendering properly when using just the reorderable list header.