### PR TITLE
Added support for uint fields

### DIFF
--- a/Assets/NaughtyAttributes/Scripts/Editor/Utility/NaughtyEditorGUI.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/Utility/NaughtyEditorGUI.cs
@@ -281,6 +281,10 @@ namespace NaughtyAttributes.Editor
 				{
 					EditorGUILayout.IntField(label, (int)value);
 				}
+				else if (valueType == typeof(uint))
+				{
+					EditorGUILayout.LongField(label, (long)value);
+				}
 				else if (valueType == typeof(long))
 				{
 					EditorGUILayout.LongField(label, (long)value);


### PR DESCRIPTION
Added support for uint fields. We use uint fields to enforce positive values but at the moment we cannot use the [ShowNonSerializedField] attribute. Casting it to a long and using a longfield resolves this.