### PR TITLE
Adding ShowAttribute / EnableAttribute with correct inspector handling

### DIFF
--- a/Assets/NaughtyAttributes/Samples/DemoScene/DemoScene.unity
+++ b/Assets/NaughtyAttributes/Samples/DemoScene/DemoScene.unity
@@ -38,12 +38,12 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657874, g: 0.49641258, b: 0.5748172, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 12
+  serializedVersion: 11
   m_GIWorkflowMode: 0
   m_GISettings:
     serializedVersion: 2
@@ -98,8 +98,7 @@ LightmapSettings:
     m_TrainingDataDestination: TrainingData
     m_LightProbeSampleCountMultiplier: 4
   m_LightingDataAsset: {fileID: 0}
-  m_LightingSettings: {fileID: 4890085278179872738, guid: 98ee975b74776234986f4d35f14c4ccc,
-    type: 2}
+  m_UseShadowmask: 1
 --- !u!196 &4
 NavMeshSettings:
   serializedVersion: 2
@@ -119,8 +118,6 @@ NavMeshSettings:
     manualTileSize: 0
     tileSize: 256
     accuratePlacement: 0
-    maxJobWorkers: 0
-    preserveTilesOutsideBounds: 0
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
@@ -163,6 +160,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 114650324}
+  - component: {fileID: 114650327}
   - component: {fileID: 114650325}
   - component: {fileID: 114650326}
   m_Layer: 0
@@ -238,6 +236,20 @@ MonoBehaviour:
       disable2: 1
       enableIfAll: {x: 0.25, y: 0.75}
       enableIfAny: {x: 0.25, y: 0.75}
+--- !u!114 &114650327
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 114650323}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8b2da8b112f54f58abc0c075f7486a1c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  disableInEditMode: 0
+  disableInPlayMode: 0
 --- !u!1 &155697335
 GameObject:
   m_ObjectHideFlags: 0
@@ -1297,6 +1309,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1524906391}
+  - component: {fileID: 1524906394}
   - component: {fileID: 1524906392}
   - component: {fileID: 1524906393}
   m_Layer: 0
@@ -1372,6 +1385,21 @@ MonoBehaviour:
       hide2: 1
       hideIfAll: {x: 0.25, y: 0.75}
       hideIfAny: {x: 0.25, y: 0.75}
+--- !u!114 &1524906394
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1524906390}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6cadd9354da448afa8fc8a74a4a0df04, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  hideInEditMode: 0
+  alwaysVisible: 0
+  hideInPlayMode: 0
 --- !u!1 &1552114399
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/NaughtyAttributes/Scripts/Core/DrawerAttributes_SpecialCase/ButtonAttribute.cs
+++ b/Assets/NaughtyAttributes/Scripts/Core/DrawerAttributes_SpecialCase/ButtonAttribute.cs
@@ -22,9 +22,28 @@ namespace NaughtyAttributes
 	public class ButtonAttribute : SpecialCaseDrawerAttribute
 	{
 		public string Text { get; private set; }
-		public EButtonEnableMode SelectedEnableMode { get; private set; }		
+		public EButtonEnableMode SelectedEnableMode { get; private set; }
 
-		public ButtonAttribute(string text = null, EButtonEnableMode enabledMode = EButtonEnableMode.Always)
+		public ButtonAttribute()
+		{
+			this.Text = null;
+			this.SelectedEnableMode = EButtonEnableMode.Always;
+		}
+		public ButtonAttribute(string text)
+		{
+			this.Text = text;
+			this.SelectedEnableMode = EButtonEnableMode.Always;
+		}
+
+		[Obsolete("enabledMode is obsolete, use [Button, EnabledInEditMode]")]
+		public ButtonAttribute(EButtonEnableMode enabledMode)
+		{
+			this.Text = null;
+			this.SelectedEnableMode = enabledMode;
+		}
+		
+		[Obsolete("enabledMode is obsolete, use [Button, EnabledInEditMode]")]
+		public ButtonAttribute(string text, EButtonEnableMode enabledMode)
 		{
 			this.Text = text;
 			this.SelectedEnableMode = enabledMode;

--- a/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/DisableInEditMode.cs
+++ b/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/DisableInEditMode.cs
@@ -1,0 +1,9 @@
+﻿using UnityEngine;
+
+namespace NaughtyAttributes
+{
+    public class DisableInEditMode : EnabledAttribute
+    {
+        public override bool Enabled => Application.isPlaying;
+    }
+}

--- a/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/DisableInEditMode.cs.meta
+++ b/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/DisableInEditMode.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 81017f39f2eb4359b576e00a933479fa
+timeCreated: 1610709263

--- a/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/DisabledInPlayMode.cs
+++ b/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/DisabledInPlayMode.cs
@@ -1,0 +1,9 @@
+﻿using UnityEngine;
+
+namespace NaughtyAttributes
+{
+    public class DisabledInPlayMode : EnabledAttribute
+    {
+        public override bool Enabled => !Application.isPlaying;
+    }
+}

--- a/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/DisabledInPlayMode.cs.meta
+++ b/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/DisabledInPlayMode.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ae1f2e36231b4a76bdaf013952b3bd37
+timeCreated: 1610709522

--- a/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/EnableIfAttributeBase.cs
+++ b/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/EnableIfAttributeBase.cs
@@ -2,8 +2,11 @@
 
 namespace NaughtyAttributes
 {
-	public abstract class EnableIfAttributeBase : MetaAttribute
+	public abstract class EnableIfAttributeBase : EnabledAttribute
 	{
+		// TODO: This is a provisional setter, once the meta attributes have been reworked, this field will be set
+		//       from the editor assembly
+		public override bool Enabled => true;
 		public string[] Conditions { get; private set; }
 		public EConditionOperator ConditionOperator { get; private set; }
 		public bool Inverted { get; protected set; }

--- a/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/EnableInEditMode.cs
+++ b/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/EnableInEditMode.cs
@@ -1,0 +1,9 @@
+﻿using UnityEngine;
+
+namespace NaughtyAttributes
+{
+    public class EnableInEditMode : EnabledAttribute
+    {
+        public override bool Enabled => !Application.isPlaying;
+    }
+}

--- a/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/EnableInEditMode.cs.meta
+++ b/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/EnableInEditMode.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a59552d21c794559b0f474669971ec80
+timeCreated: 1610709216

--- a/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/EnableInPlayMode.cs
+++ b/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/EnableInPlayMode.cs
@@ -1,0 +1,9 @@
+﻿using UnityEngine;
+
+namespace NaughtyAttributes
+{
+    public class EnableInPlayMode : EnabledAttribute
+    {
+        public override bool Enabled => Application.isPlaying;
+    }
+}

--- a/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/EnableInPlayMode.cs.meta
+++ b/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/EnableInPlayMode.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 4a07cb6c44254e38ae66b6edf0c68670
+timeCreated: 1610709148

--- a/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/EnabledAttribute.cs
+++ b/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/EnabledAttribute.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace NaughtyAttributes
+{
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
+    public abstract class EnabledAttribute : MetaAttribute, IEnabledAttribute
+    {
+        public abstract bool Enabled { get; }
+    }
+}

--- a/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/EnabledAttribute.cs.meta
+++ b/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/EnabledAttribute.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d8f31c8b7ebe40939e1750955c75a069
+timeCreated: 1610708723

--- a/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/HideInEditMode.cs
+++ b/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/HideInEditMode.cs
@@ -1,0 +1,9 @@
+﻿using UnityEngine;
+
+namespace NaughtyAttributes
+{
+    public class HideInEditMode : ShowAttribute
+    {
+        public override bool Visible => Application.isPlaying;
+    }
+}

--- a/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/HideInEditMode.cs.meta
+++ b/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/HideInEditMode.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 363037bb78da46419ca545585e12bc98
+timeCreated: 1610711472

--- a/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/HideInPlayMode.cs
+++ b/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/HideInPlayMode.cs
@@ -1,0 +1,9 @@
+﻿using UnityEngine;
+
+namespace NaughtyAttributes
+{
+    public class HideInPlayMode : ShowAttribute
+    {
+        public override bool Visible => !Application.isPlaying;
+    }
+}

--- a/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/HideInPlayMode.cs.meta
+++ b/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/HideInPlayMode.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 8859ba77b97643b7871f3ecc8807beba
+timeCreated: 1610711566

--- a/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/IEnabledAttribute.cs
+++ b/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/IEnabledAttribute.cs
@@ -1,0 +1,7 @@
+﻿namespace NaughtyAttributes
+{
+    public interface IEnabledAttribute
+    {
+        bool Enabled { get; }
+    }
+}

--- a/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/IEnabledAttribute.cs.meta
+++ b/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/IEnabledAttribute.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0b78381a6c38470ab5d44a840e38a8ac
+timeCreated: 1610708685

--- a/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/IShowAttribute.cs
+++ b/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/IShowAttribute.cs
@@ -1,0 +1,7 @@
+﻿namespace NaughtyAttributes
+{
+    public interface IShowAttribute
+    {
+        bool Visible { get; }
+    }
+}

--- a/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/IShowAttribute.cs.meta
+++ b/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/IShowAttribute.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 2c0338f1d46540d1b01975708689253f
+timeCreated: 1610710365

--- a/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/ShowAttribute.cs
+++ b/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/ShowAttribute.cs
@@ -1,0 +1,7 @@
+﻿namespace NaughtyAttributes
+{
+    public abstract class ShowAttribute : MetaAttribute, IShowAttribute
+    {
+        public abstract bool Visible { get; }
+    }
+}

--- a/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/ShowAttribute.cs.meta
+++ b/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/ShowAttribute.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d95c4b289b204250ad832d048ae3a3fb
+timeCreated: 1610710698

--- a/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/ShowIfAttributeBase.cs
+++ b/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/ShowIfAttributeBase.cs
@@ -2,8 +2,11 @@
 
 namespace NaughtyAttributes
 {
-	public class ShowIfAttributeBase : MetaAttribute
+	public class ShowIfAttributeBase : ShowAttribute
 	{
+		// TODO: This is a provisional setter, once the meta attributes have been reworked, this field will be set
+		//       from the editor assembly
+		public override bool Visible => true;
 		public string[] Conditions { get; private set; }
 		public EConditionOperator ConditionOperator { get; private set; }
 		public bool Inverted { get; protected set; }

--- a/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/ShowInEditMode.cs
+++ b/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/ShowInEditMode.cs
@@ -1,0 +1,9 @@
+﻿using UnityEngine;
+
+namespace NaughtyAttributes
+{
+    public class ShowInEditMode : ShowAttribute
+    {
+        public override bool Visible => !Application.isPlaying;
+    }
+}

--- a/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/ShowInEditMode.cs.meta
+++ b/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/ShowInEditMode.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0a753a53c098443c99b8799e8109aac7
+timeCreated: 1610711365

--- a/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/ShowInPlayMode.cs
+++ b/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/ShowInPlayMode.cs
@@ -1,0 +1,9 @@
+﻿using UnityEngine;
+
+namespace NaughtyAttributes
+{
+    public class ShowInPlayMode : ShowAttribute
+    {
+        public override bool Visible => Application.isPlaying;
+    }
+}

--- a/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/ShowInPlayMode.cs.meta
+++ b/Assets/NaughtyAttributes/Scripts/Core/MetaAttributes/ShowInPlayMode.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 019c9ab08117454ab0c56a90775b0e82
+timeCreated: 1610711422

--- a/Assets/NaughtyAttributes/Scripts/Editor/Utility/ButtonUtility.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/Utility/ButtonUtility.cs
@@ -8,48 +8,56 @@ namespace NaughtyAttributes.Editor
 	{
 		public static bool IsEnabled(Object target, MethodInfo method)
 		{
-			EnableIfAttributeBase enableIfAttribute = method.GetCustomAttribute<EnableIfAttributeBase>();
-			if (enableIfAttribute == null)
+			var enabled = true;
+			var attributes = method.GetCustomAttributes<EnabledAttribute>();
+			foreach (var attribute in attributes)
 			{
-				return true;
-			}
+				if (attribute is EnableIfAttributeBase enableIfAttribute)
+				{
+					var conditions = PropertyUtility.GetConditionValues(target, enableIfAttribute.Conditions);
+					if (conditions.Count > 0)
+					{
+						enabled &= PropertyUtility.GetConditionsFlag(conditions, enableIfAttribute.ConditionOperator, enableIfAttribute.Inverted);
+					}
+					else
+					{
+						string message = enableIfAttribute.GetType().Name + " needs a valid boolean condition field, property or method name to work";
+						Debug.LogWarning(message, target);
 
-			List<bool> conditionValues = PropertyUtility.GetConditionValues(target, enableIfAttribute.Conditions);
-			if (conditionValues.Count > 0)
-			{
-				bool enabled = PropertyUtility.GetConditionsFlag(conditionValues, enableIfAttribute.ConditionOperator, enableIfAttribute.Inverted);
-				return enabled;
+					}
+					continue;
+				}
+				enabled &= attribute.Enabled;
 			}
-			else
-			{
-				string message = enableIfAttribute.GetType().Name + " needs a valid boolean condition field, property or method name to work";
-				Debug.LogWarning(message, target);
-
-				return false;
-			}
+			return enabled;
 		}
 
 		public static bool IsVisible(Object target, MethodInfo method)
 		{
-			ShowIfAttributeBase showIfAttribute = method.GetCustomAttribute<ShowIfAttributeBase>();
-			if (showIfAttribute == null)
-			{
-				return true;
-			}
+			var visible = true;
+			var attributes = method.GetCustomAttributes<ShowAttribute>();
 
-			List<bool> conditionValues = PropertyUtility.GetConditionValues(target, showIfAttribute.Conditions);
-			if (conditionValues.Count > 0)
+			foreach (var attribute in attributes)
 			{
-				bool enabled = PropertyUtility.GetConditionsFlag(conditionValues, showIfAttribute.ConditionOperator, showIfAttribute.Inverted);
-				return enabled;
-			}
-			else
-			{
-				string message = showIfAttribute.GetType().Name + " needs a valid boolean condition field, property or method name to work";
-				Debug.LogWarning(message, target);
+				if (attribute is ShowIfAttributeBase showIfAttribute)
+				{
+					List<bool> conditionValues = PropertyUtility.GetConditionValues(target, showIfAttribute.Conditions);
+					if (conditionValues.Count > 0)
+					{
+						visible &= PropertyUtility.GetConditionsFlag(conditionValues, showIfAttribute.ConditionOperator, showIfAttribute.Inverted);
+					}
+					else
+					{
+						string message = showIfAttribute.GetType().Name + " needs a valid boolean condition field, property or method name to work";
+						Debug.LogWarning(message, target);
 
-				return false;
+						visible &= false;
+					}
+					continue;
+				}
+				visible &= attribute.Visible;
 			}
+			return visible;
 		}
 	}
 }

--- a/Assets/NaughtyAttributes/Scripts/Test/ButtonTest.cs
+++ b/Assets/NaughtyAttributes/Scripts/Test/ButtonTest.cs
@@ -35,5 +35,17 @@ namespace NaughtyAttributes.Test
 				yield return new WaitForSeconds(1.0f);
 			}
 		}
+		
+		[Button, DisabledInPlayMode]
+		private void OnlyEnabledInEditMode() { }
+		
+		[Button, DisableInEditMode]
+		private void OnlyEnabledInPlayMode() { }
+		
+		[Button, HideInPlayMode]
+		private void OnlyVisibleInEditMode() { }
+		
+		[Button, HideInEditMode]
+		private void OnlyVisibleInPlayMode() { }
 	}
 }

--- a/Assets/NaughtyAttributes/Scripts/Test/EnableTest.cs
+++ b/Assets/NaughtyAttributes/Scripts/Test/EnableTest.cs
@@ -1,0 +1,13 @@
+﻿using UnityEngine;
+
+namespace NaughtyAttributes.Test
+{
+    public class EnableTest : MonoBehaviour
+    {
+        [DisabledInPlayMode]
+        public bool disableInEditMode;
+		
+        [DisableInEditMode]
+        public bool disableInPlayMode;
+    }
+}

--- a/Assets/NaughtyAttributes/Scripts/Test/EnableTest.cs.meta
+++ b/Assets/NaughtyAttributes/Scripts/Test/EnableTest.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 8b2da8b112f54f58abc0c075f7486a1c
+timeCreated: 1610712525

--- a/Assets/NaughtyAttributes/Scripts/Test/HideTest.cs
+++ b/Assets/NaughtyAttributes/Scripts/Test/HideTest.cs
@@ -1,0 +1,16 @@
+﻿using UnityEngine;
+
+namespace NaughtyAttributes.Test
+{
+    public class HideTest : MonoBehaviour
+    {
+        [HideInEditMode]
+        public bool hideInEditMode;
+
+        public bool alwaysVisible;
+        
+        [HideInPlayMode]
+        public bool hideInPlayMode;
+
+    }
+}

--- a/Assets/NaughtyAttributes/Scripts/Test/HideTest.cs.meta
+++ b/Assets/NaughtyAttributes/Scripts/Test/HideTest.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 6cadd9354da448afa8fc8a74a4a0df04
+timeCreated: 1610712555


### PR DESCRIPTION
In this PR there have been following additions:

- `ShowAttribute` as base class for all ShowAttributes, including `ShowIfAttributeBase`
  - `HideInEditMode`
  - `HideInPlayMode`
  - `ShowInEditMode` (lack override logic in inspector)
  - `ShowInPlayMode` (lack override logic in inspector)
- `EnableAttribute` as base class for all EnableAttributes, including `EnableIfAttributeBase`
  - `DisableInEditMode`
  - `DisableInPlayMode`
  - `ShowInEditMode` (lacks override logic in inspector)
  - `ShowInPlayMode` (lack override logic in inspector)
- `DisableTest` and `HideTest` for showcasing

Following changes have been included:

- `EButtonEnableMode` has been marked as obsolete, to incorporate legacy support, but encouraging attribute stacking
- Appropriate changes to `IsEnable` and `IsVisible` Methods on `PropertyUtility` and `ButtonUtility`