### PR TITLE
Adding support for Vector2Int for MinMaxSlider

### DIFF
--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/MinMaxSliderPropertyDrawer.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/MinMaxSliderPropertyDrawer.cs
@@ -8,7 +8,7 @@ namespace NaughtyAttributes.Editor
 	{
 		protected override float GetPropertyHeight_Internal(SerializedProperty property, GUIContent label)
 		{
-			return (property.propertyType == SerializedPropertyType.Vector2)
+			return (property.propertyType == SerializedPropertyType.Vector2 || property.propertyType == SerializedPropertyType.Vector2Int)
 				? GetPropertyHeight(property)
 				: GetPropertyHeight(property) + GetHelpBoxHeight();
 		}
@@ -19,7 +19,7 @@ namespace NaughtyAttributes.Editor
 
 			MinMaxSliderAttribute minMaxSliderAttribute = (MinMaxSliderAttribute)attribute;
 
-			if (property.propertyType == SerializedPropertyType.Vector2)
+			if (property.propertyType == SerializedPropertyType.Vector2 || property.propertyType == SerializedPropertyType.Vector2Int)
 			{
 				EditorGUI.BeginProperty(rect, label, property);
 
@@ -59,25 +59,44 @@ namespace NaughtyAttributes.Editor
 				// Draw the slider
 				EditorGUI.BeginChangeCheck();
 
-				Vector2 sliderValue = property.vector2Value;
-				EditorGUI.MinMaxSlider(sliderRect, ref sliderValue.x, ref sliderValue.y, minMaxSliderAttribute.MinValue, minMaxSliderAttribute.MaxValue);
-
-				sliderValue.x = EditorGUI.FloatField(minFloatFieldRect, sliderValue.x);
-				sliderValue.x = Mathf.Clamp(sliderValue.x, minMaxSliderAttribute.MinValue, Mathf.Min(minMaxSliderAttribute.MaxValue, sliderValue.y));
-
-				sliderValue.y = EditorGUI.FloatField(maxFloatFieldRect, sliderValue.y);
-				sliderValue.y = Mathf.Clamp(sliderValue.y, Mathf.Max(minMaxSliderAttribute.MinValue, sliderValue.x), minMaxSliderAttribute.MaxValue);
-
-				if (EditorGUI.EndChangeCheck())
+				if (property.propertyType == SerializedPropertyType.Vector2)
 				{
-					property.vector2Value = sliderValue;
+					Vector2 sliderValue = property.vector2Value;
+					EditorGUI.MinMaxSlider(sliderRect, ref sliderValue.x, ref sliderValue.y, minMaxSliderAttribute.MinValue, minMaxSliderAttribute.MaxValue);
+
+					sliderValue.x = EditorGUI.FloatField(minFloatFieldRect, sliderValue.x);
+					sliderValue.x = Mathf.Clamp(sliderValue.x, minMaxSliderAttribute.MinValue, Mathf.Min(minMaxSliderAttribute.MaxValue, sliderValue.y));
+
+					sliderValue.y = EditorGUI.FloatField(maxFloatFieldRect, sliderValue.y);
+					sliderValue.y = Mathf.Clamp(sliderValue.y, Mathf.Max(minMaxSliderAttribute.MinValue, sliderValue.x), minMaxSliderAttribute.MaxValue);
+
+					if (EditorGUI.EndChangeCheck()) {
+						property.vector2Value = sliderValue;
+					}
+				}
+				else if (property.propertyType == SerializedPropertyType.Vector2Int)
+				{
+					Vector2Int sliderValue = property.vector2IntValue;
+					float xValue = sliderValue.x;
+					float yValue = sliderValue.y;
+					EditorGUI.MinMaxSlider(sliderRect, ref xValue, ref yValue, minMaxSliderAttribute.MinValue, minMaxSliderAttribute.MaxValue);
+
+					sliderValue.x = EditorGUI.IntField(minFloatFieldRect, (int)xValue);
+					sliderValue.x = (int)Mathf.Clamp(sliderValue.x, minMaxSliderAttribute.MinValue, Mathf.Min(minMaxSliderAttribute.MaxValue, sliderValue.y));
+
+					sliderValue.y = EditorGUI.IntField(maxFloatFieldRect, (int)yValue);
+					sliderValue.y = (int)Mathf.Clamp(sliderValue.y, Mathf.Max(minMaxSliderAttribute.MinValue, sliderValue.x), minMaxSliderAttribute.MaxValue);
+
+					if (EditorGUI.EndChangeCheck()) {
+						property.vector2IntValue = sliderValue;
+					}
 				}
 
 				EditorGUI.EndProperty();
 			}
 			else
 			{
-				string message = minMaxSliderAttribute.GetType().Name + " can be used only on Vector2 fields";
+				string message = minMaxSliderAttribute.GetType().Name + " can be used only on Vector2 or Vector2Int fields";
 				DrawDefaultPropertyAndHelpBox(rect, property, message, MessageType.Warning);
 			}
 


### PR DESCRIPTION
Currently the `MinMaxSlider` attribute only supports `Vector2`. This small PR adds support for `Vector2Int`.