### PR TITLE
#217 support enum flags

### DIFF
--- a/Assets/NaughtyAttributes/Scripts/Editor/Utility/PropertyUtility.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/Utility/PropertyUtility.cs
@@ -90,7 +90,11 @@ namespace NaughtyAttributes.Editor
 				Enum value = GetEnumValue(target, enableIfAttribute.Conditions[0]);
 				if (value != null)
 				{
-					return enableIfAttribute.EnumValue.Equals(value) != enableIfAttribute.Inverted;
+					bool matched = value.GetType().GetCustomAttribute<FlagsAttribute>() == null
+						? enableIfAttribute.EnumValue.Equals(value)
+						: value.HasFlag(enableIfAttribute.EnumValue);
+
+					return matched != enableIfAttribute.Inverted;
 				}
 
 				string message = enableIfAttribute.GetType().Name + " needs a valid enum field, property or method name to work";
@@ -128,10 +132,15 @@ namespace NaughtyAttributes.Editor
 			// deal with enum conditions
 			if (showIfAttribute.EnumValue != null)
 			{
+
 				Enum value = GetEnumValue(target, showIfAttribute.Conditions[0]);
 				if (value != null)
 				{
-					return showIfAttribute.EnumValue.Equals(value) != showIfAttribute.Inverted;
+					bool matched = value.GetType().GetCustomAttribute<FlagsAttribute>() == null
+						? showIfAttribute.EnumValue.Equals(value)
+						: value.HasFlag(showIfAttribute.EnumValue);
+
+					return matched != showIfAttribute.Inverted;
 				}
 
 				string message = showIfAttribute.GetType().Name + " needs a valid enum field, property or method name to work";

--- a/Assets/NaughtyAttributes/Scripts/Test/DisableIfTest.cs
+++ b/Assets/NaughtyAttributes/Scripts/Test/DisableIfTest.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System;
+using UnityEngine;
 
 namespace NaughtyAttributes.Test
 {
@@ -7,6 +8,7 @@ namespace NaughtyAttributes.Test
 		public bool disable1;
 		public bool disable2;
 		public DisableIfEnum enum1;
+		[EnumFlags] public DisableIfEnumFlag enum2;
 
 		[DisableIf(EConditionOperator.And, "disable1", "disable2")]
 		[ReorderableList]
@@ -20,6 +22,14 @@ namespace NaughtyAttributes.Test
 		[ReorderableList]
 		public int[] disableIfEnum;
 
+		[DisableIf("enum2", DisableIfEnumFlag.Flag0)]
+		[ReorderableList]
+		public int[] disableIfEnumFlag;
+
+		[DisableIf("enum2", DisableIfEnumFlag.Flag0 | DisableIfEnumFlag.Flag1)]
+		[ReorderableList]
+		public int[] disableIfEnumFlagMulti;
+
 		public DisableIfNest1 nest1;
 	}
 
@@ -29,9 +39,11 @@ namespace NaughtyAttributes.Test
 		public bool disable1;
 		public bool disable2;
 		public DisableIfEnum enum1;
+		[EnumFlags] public DisableIfEnumFlag enum2;
 		public bool Disable1 { get { return disable1; } }
 		public bool Disable2 { get { return disable2; } }
 		public DisableIfEnum Enum1 { get { return enum1; } }
+		public DisableIfEnumFlag Enum2 { get { return enum2; } }
 
 		[DisableIf(EConditionOperator.And, "Disable1", "Disable2")]
 		[AllowNesting] // Because it's nested we need to explicitly allow nesting
@@ -45,6 +57,14 @@ namespace NaughtyAttributes.Test
 		[AllowNesting] // Because it's nested we need to explicitly allow nesting
 		public int disableIfEnum = 3;
 
+		[DisableIf("Enum2", DisableIfEnumFlag.Flag0)]
+		[AllowNesting] // Because it's nested we need to explicitly allow nesting
+		public int disableIfEnumFlag;
+
+		[DisableIf("Enum2", DisableIfEnumFlag.Flag0 | DisableIfEnumFlag.Flag1)]
+		[AllowNesting] // Because it's nested we need to explicitly allow nesting
+		public int disableIfEnumFlagMulti;
+
 		public DisableIfNest2 nest2;
 	}
 
@@ -54,9 +74,11 @@ namespace NaughtyAttributes.Test
 		public bool disable1;
 		public bool disable2;
 		public DisableIfEnum enum1;
+		[EnumFlags] public DisableIfEnumFlag enum2;
 		public bool GetDisable1() { return disable1; }
 		public bool GetDisable2() { return disable2; }
 		public DisableIfEnum GetEnum1() { return enum1; }
+		public DisableIfEnumFlag GetEnum2() { return enum2; }
 
 		[DisableIf(EConditionOperator.And, "GetDisable1", "GetDisable2")]
 		[MinMaxSlider(0.0f, 1.0f)] // AllowNesting attribute is not needed, because the field is already marked with a custom naughty property drawer
@@ -69,6 +91,14 @@ namespace NaughtyAttributes.Test
 		[DisableIf("GetEnum1", DisableIfEnum.Case2)]
 		[MinMaxSlider(0.0f, 1.0f)] // AllowNesting attribute is not needed, because the field is already marked with a custom naughty property drawer
 		public Vector2 enableIfEnum = new Vector2(0.25f, 0.75f);
+
+		[DisableIf("GetEnum2", DisableIfEnumFlag.Flag0)]
+		[MinMaxSlider(0.0f, 1.0f)] // AllowNesting attribute is not needed, because the field is already marked with a custom naughty property drawer
+		public Vector2 disableIfEnumFlag;
+
+		[DisableIf("GetEnum2", DisableIfEnumFlag.Flag0 | DisableIfEnumFlag.Flag1)]
+		[MinMaxSlider(0.0f, 1.0f)] // AllowNesting attribute is not needed, because the field is already marked with a custom naughty property drawer
+		public Vector2 disableIfEnumFlagMulti;
 	}
 
 	[System.Serializable]
@@ -77,5 +107,14 @@ namespace NaughtyAttributes.Test
 		Case0,
 		Case1,
 		Case2
+	}
+
+	[Flags]
+	public enum DisableIfEnumFlag
+	{
+		Flag0 = 1,
+		Flag1 = 2,
+		Flag2 = 4,
+		Flag3 = 8
 	}
 }

--- a/Assets/NaughtyAttributes/Scripts/Test/EnableIfTest.cs
+++ b/Assets/NaughtyAttributes/Scripts/Test/EnableIfTest.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 
 namespace NaughtyAttributes.Test
@@ -7,6 +8,7 @@ namespace NaughtyAttributes.Test
 		public bool enable1;
 		public bool enable2;
 		public EnableIfEnum enum1;
+		[EnumFlags] public EnableIfEnumFlag enum2;
 
 		[EnableIf(EConditionOperator.And, "enable1", "enable2")]
 		[ReorderableList]
@@ -20,6 +22,14 @@ namespace NaughtyAttributes.Test
 		[ReorderableList]
 		public int[] enableIfEnum;
 
+		[EnableIf("enum2", EnableIfEnumFlag.Flag0)]
+		[ReorderableList]
+		public int[] enableIfEnumFlag;
+
+		[EnableIf("enum2", EnableIfEnumFlag.Flag0 | EnableIfEnumFlag.Flag1)]
+		[ReorderableList]
+		public int[] enableIfEnumFlagMulti;
+
 		public EnableIfNest1 nest1;
 	}
 
@@ -29,9 +39,11 @@ namespace NaughtyAttributes.Test
 		public bool enable1;
 		public bool enable2;
 		public EnableIfEnum enum1;
+		[EnumFlags] public EnableIfEnumFlag enum2;
 		public bool Enable1 { get { return enable1; } }
 		public bool Enable2 { get { return enable2; } }
 		public EnableIfEnum Enum1 { get { return enum1; } }
+		public EnableIfEnumFlag Enum2 { get { return enum2; } }
 
 		[EnableIf(EConditionOperator.And, "Enable1", "Enable2")]
 		[AllowNesting] // Because it's nested we need to explicitly allow nesting
@@ -45,6 +57,14 @@ namespace NaughtyAttributes.Test
 		[AllowNesting] // Because it's nested we need to explicitly allow nesting
 		public int enableIfEnum;
 
+		[EnableIf("Enum2", EnableIfEnumFlag.Flag0)]
+		[AllowNesting] // Because it's nested we need to explicitly allow nesting
+		public int enableIfEnumFlag;
+
+		[EnableIf("Enum2", EnableIfEnumFlag.Flag0 | EnableIfEnumFlag.Flag1)]
+		[AllowNesting] // Because it's nested we need to explicitly allow nesting
+		public int enableIfEnumFlagMulti;
+
 		public EnableIfNest2 nest2;
 	}
 
@@ -54,9 +74,11 @@ namespace NaughtyAttributes.Test
 		public bool enable1;
 		public bool enable2;
 		public EnableIfEnum enum1;
+		[EnumFlags] public EnableIfEnumFlag enum2;
 		public bool GetEnable1() { return enable1; }
 		public bool GetEnable2() { return enable2; }
 		public EnableIfEnum GetEnum1() { return enum1; }
+		public EnableIfEnumFlag GetEnum2() { return enum2; }
 
 		[EnableIf(EConditionOperator.And, "GetEnable1", "GetEnable2")]
 		[MinMaxSlider(0.0f, 1.0f)] // AllowNesting attribute is not needed, because the field is already marked with a custom naughty property drawer
@@ -69,6 +91,14 @@ namespace NaughtyAttributes.Test
 		[EnableIf("GetEnum1", EnableIfEnum.Case2)]
 		[MinMaxSlider(0.0f, 1.0f)] // AllowNesting attribute is not needed, because the field is already marked with a custom naughty property drawer
 		public Vector2 enableIfEnum = new Vector2(0.25f, 0.75f);
+
+		[EnableIf("GetEnum2", EnableIfEnumFlag.Flag0)]
+		[MinMaxSlider(0.0f, 1.0f)] // AllowNesting attribute is not needed, because the field is already marked with a custom naughty property drawer
+		public Vector2 enableIfEnumFlag;
+
+		[EnableIf("GetEnum2", EnableIfEnumFlag.Flag0 | EnableIfEnumFlag.Flag1)]
+		[MinMaxSlider(0.0f, 1.0f)] // AllowNesting attribute is not needed, because the field is already marked with a custom naughty property drawer
+		public Vector2 enableIfEnumFlagMulti;
 	}
 
 	[System.Serializable]
@@ -77,5 +107,14 @@ namespace NaughtyAttributes.Test
 		Case0,
 		Case1,
 		Case2
+	}
+
+	[Flags]
+	public enum EnableIfEnumFlag
+	{
+		Flag0 = 1,
+		Flag1 = 2,
+		Flag2 = 4,
+		Flag3 = 8
 	}
 }

--- a/Assets/NaughtyAttributes/Scripts/Test/HideIfTest.cs
+++ b/Assets/NaughtyAttributes/Scripts/Test/HideIfTest.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System;
+using UnityEngine;
 
 namespace NaughtyAttributes.Test
 {
@@ -7,6 +8,7 @@ namespace NaughtyAttributes.Test
 		public bool hide1;
 		public bool hide2;
 		public HideIfEnum enum1;
+		[EnumFlags] public HideIfEnumFlag enum2;
 
 		[HideIf(EConditionOperator.And, "hide1", "hide2")]
 		[ReorderableList]
@@ -20,6 +22,14 @@ namespace NaughtyAttributes.Test
 		[ReorderableList]
 		public int[] hideIfEnum;
 
+		[HideIf("enum2", HideIfEnumFlag.Flag0)]
+		[ReorderableList]
+		public int[] hideIfEnumFlag;
+
+		[HideIf("enum2", HideIfEnumFlag.Flag0 | HideIfEnumFlag.Flag1)]
+		[ReorderableList]
+		public int[] hideIfEnumFlagMulti;
+
 		public HideIfNest1 nest1;
 	}
 
@@ -29,9 +39,11 @@ namespace NaughtyAttributes.Test
 		public bool hide1;
 		public bool hide2;
 		public HideIfEnum enum1;
+		[EnumFlags] public HideIfEnumFlag enum2;
 		public bool Hide1 { get { return hide1; } }
 		public bool Hide2 { get { return hide2; } }
 		public HideIfEnum Enum1 { get { return enum1; } }
+		public HideIfEnumFlag Enum2 { get { return enum2; } }
 
 		[HideIf(EConditionOperator.And, "Hide1", "Hide2")]
 		[AllowNesting] // Because it's nested we need to explicitly allow nesting
@@ -45,6 +57,14 @@ namespace NaughtyAttributes.Test
 		[AllowNesting] // Because it's nested we need to explicitly allow nesting
 		public int hideIfEnum;
 
+		[HideIf("Enum2", HideIfEnumFlag.Flag0)]
+		[AllowNesting]
+		public int hideIfEnumFlag;
+
+		[HideIf("Enum2", HideIfEnumFlag.Flag0 | HideIfEnumFlag.Flag1)]
+		[AllowNesting]
+		public int hideIfEnumFlagMulti;
+
 		public HideIfNest2 nest2;
 	}
 
@@ -54,9 +74,11 @@ namespace NaughtyAttributes.Test
 		public bool hide1;
 		public bool hide2;
 		public HideIfEnum enum1;
+		[EnumFlags] public HideIfEnumFlag enum2;
 		public bool GetHide1() { return hide1; }
 		public bool GetHide2() { return hide2; }
 		public HideIfEnum GetEnum1() { return enum1; }
+		public HideIfEnumFlag GetEnum2() { return enum2; }
 
 		[HideIf(EConditionOperator.And, "GetHide1", "GetHide2")]
 		[MinMaxSlider(0.0f, 1.0f)] // AllowNesting attribute is not needed, because the field is already marked with a custom naughty property drawer
@@ -69,6 +91,14 @@ namespace NaughtyAttributes.Test
 		[HideIf("GetEnum1", HideIfEnum.Case2)]
 		[MinMaxSlider(0.0f, 1.0f)] // AllowNesting attribute is not needed, because the field is already marked with a custom naughty property drawer
 		public Vector2 hideIfEnum = new Vector2(0.25f, 0.75f);
+
+		[HideIf("GetEnum2", HideIfEnumFlag.Flag0)]
+		[MinMaxSlider(0.0f, 1.0f)] // AllowNesting attribute is not needed, because the field is already marked with a custom naughty property drawer
+		public Vector2 hideIfEnumFlag;
+
+		[HideIf("GetEnum2", HideIfEnumFlag.Flag0 | HideIfEnumFlag.Flag1)]
+		[MinMaxSlider(0.0f, 1.0f)] // AllowNesting attribute is not needed, because the field is already marked with a custom naughty property drawer
+		public Vector2 hideIfEnumFlagMulti;
 	}
 
 	public enum HideIfEnum
@@ -76,5 +106,14 @@ namespace NaughtyAttributes.Test
 		Case0,
 		Case1,
 		Case2
+	}
+
+	[Flags]
+	public enum HideIfEnumFlag
+	{
+		Flag0 = 1,
+		Flag1 = 2,
+		Flag2 = 4,
+		Flag3 = 8
 	}
 }

--- a/Assets/NaughtyAttributes/Scripts/Test/ShowIfTest.cs
+++ b/Assets/NaughtyAttributes/Scripts/Test/ShowIfTest.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 
 namespace NaughtyAttributes.Test
@@ -7,6 +8,7 @@ namespace NaughtyAttributes.Test
 		public bool show1;
 		public bool show2;
 		public ShowIfEnum enum1;
+		[EnumFlags] public ShowIfEnumFlag enum2;
 
 		[ShowIf(EConditionOperator.And, "show1", "show2")]
 		[ReorderableList]
@@ -20,6 +22,14 @@ namespace NaughtyAttributes.Test
 		[ReorderableList]
 		public int[] showIfEnum;
 
+		[ShowIf("enum2", ShowIfEnumFlag.Flag0)]
+		[ReorderableList]
+		public int[] showIfEnumFlag;
+
+		[ShowIf("enum2", ShowIfEnumFlag.Flag0 | ShowIfEnumFlag.Flag1)]
+		[ReorderableList]
+		public int[] showIfEnumFlagMulti;
+
 		public ShowIfNest1 nest1;
 	}
 
@@ -29,9 +39,11 @@ namespace NaughtyAttributes.Test
 		public bool show1;
 		public bool show2;
 		public ShowIfEnum enum1;
+		[EnumFlags] public ShowIfEnumFlag enum2;
 		public bool Show1 { get { return show1; } }
 		public bool Show2 { get { return show2; } }
 		public ShowIfEnum Enum1 { get { return enum1; } }
+		public ShowIfEnumFlag Enum2 { get { return enum2; } }
 
 		[ShowIf(EConditionOperator.And, "Show1", "Show2")]
 		[AllowNesting] // Because it's nested we need to explicitly allow nesting
@@ -45,6 +57,14 @@ namespace NaughtyAttributes.Test
 		[AllowNesting] // Because it's nested we need to explicitly allow nesting
 		public int showIfEnum;
 
+		[ShowIf("Enum2", ShowIfEnumFlag.Flag0)]
+		[AllowNesting]
+		public int showIfEnumFlag;
+
+		[ShowIf("Enum2", ShowIfEnumFlag.Flag0 | ShowIfEnumFlag.Flag1)]
+		[AllowNesting]
+		public int showIfEnumFlagMulti;
+
 		public ShowIfNest2 nest2;
 	}
 
@@ -54,9 +74,11 @@ namespace NaughtyAttributes.Test
 		public bool show1;
 		public bool show2;
 		public ShowIfEnum enum1;
+		[EnumFlags] public ShowIfEnumFlag enum2;
 		public bool GetShow1() { return show1; }
 		public bool GetShow2() { return show2; }
 		public ShowIfEnum GetEnum1() { return enum1; }
+		public ShowIfEnumFlag GetEnum2() { return enum2; }
 
 		[ShowIf(EConditionOperator.And, "GetShow1", "GetShow2")]
 		[MinMaxSlider(0.0f, 1.0f)] // AllowNesting attribute is not needed, because the field is already marked with a custom naughty property drawer
@@ -69,6 +91,14 @@ namespace NaughtyAttributes.Test
 		[ShowIf("GetEnum1", ShowIfEnum.Case2)]
 		[MinMaxSlider(0.0f, 1.0f)] // AllowNesting attribute is not needed, because the field is already marked with a custom naughty property drawer
 		public Vector2 showIfEnum = new Vector2(0.25f, 0.75f);
+
+		[ShowIf("GetEnum2", ShowIfEnumFlag.Flag0)]
+		[MinMaxSlider(0.0f, 1.0f)] // AllowNesting attribute is not needed, because the field is already marked with a custom naughty property drawer
+		public Vector2 showIfEnumFlag;
+
+		[ShowIf("GetEnum2", ShowIfEnumFlag.Flag0 | ShowIfEnumFlag.Flag1)]
+		[MinMaxSlider(0.0f, 1.0f)] // AllowNesting attribute is not needed, because the field is already marked with a custom naughty property drawer
+		public Vector2 showIfEnumFlagMulti;
 	}
 
 	public enum ShowIfEnum
@@ -76,5 +106,14 @@ namespace NaughtyAttributes.Test
 		Case0,
 		Case1,
 		Case2
+	}
+
+	[Flags]
+	public enum ShowIfEnumFlag
+	{
+		Flag0 = 1,
+		Flag1 = 2,
+		Flag2 = 4,
+		Flag3 = 8
 	}
 }


### PR DESCRIPTION
Resolve #217 
```C#
public MyEnumFlag myEnum;

// Will be enabled if flag0 is cheched in myEnum
[EnableIf("myEnum", MyEnumFlag.Flag0)]

// Will be enabled if flag0 and flag1 are both checked in myEnum
[EnableIf("myEnum", MyEnumFlag.Flag0 | MyEnumFlag.Flag1)]
```
Notice that only enum types annotated with [System.Flags] attribute will be considered as flags.
![EnumFlag](https://user-images.githubusercontent.com/44696723/116369744-4b507400-a83c-11eb-8ab4-53faebcb86e9.gif)
