### PR TITLE
Applying NaughtyAttribute's meta attributes to non-Unity Object derived types

### DIFF
--- a/Assets/NaughtyAttributes/Samples/DemoScene/DemoScene.unity
+++ b/Assets/NaughtyAttributes/Samples/DemoScene/DemoScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657874, g: 0.49641258, b: 0.5748172, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -150,6 +150,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1148579784}
   m_RootOrder: 0
@@ -182,6 +183,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1148579784}
   m_RootOrder: 23
@@ -201,23 +203,32 @@ MonoBehaviour:
   enable1: 0
   enable2: 0
   enum1: 0
+  enum2: 0
   enableIfAll: 
   enableIfAny: 
   enableIfEnum: 
+  enableIfEnumFlag: 
+  enableIfEnumFlagMulti: 
   nest1:
     enable1: 1
     enable2: 0
     enum1: 0
+    enum2: 0
     enableIfAll: 1
     enableIfAny: 2
     enableIfEnum: 0
+    enableIfEnumFlag: 0
+    enableIfEnumFlagMulti: 0
     nest2:
       enable1: 1
       enable2: 1
       enum1: 0
+      enum2: 0
       enableIfAll: {x: 0.25, y: 0.75}
       enableIfAny: {x: 0.25, y: 0.75}
       enableIfEnum: {x: 0.25, y: 0.75}
+      enableIfEnumFlag: {x: 0, y: 0}
+      enableIfEnumFlagMulti: {x: 0, y: 0}
 --- !u!114 &114650326
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -233,23 +244,32 @@ MonoBehaviour:
   disable1: 0
   disable2: 0
   enum1: 0
+  enum2: 0
   disableIfAll: 
   disableIfAny: 
   disableIfEnum: 
+  disableIfEnumFlag: 
+  disableIfEnumFlagMulti: 
   nest1:
     disable1: 1
     disable2: 0
     enum1: 0
+    enum2: 0
     disableIfAll: 1
     disableIfAny: 2
     disableIfEnum: 3
+    disableIfEnumFlag: 0
+    disableIfEnumFlagMulti: 0
     nest2:
       disable1: 1
       disable2: 1
       enum1: 0
+      enum2: 0
       enableIfAll: {x: 0.25, y: 0.75}
       enableIfAny: {x: 0.25, y: 0.75}
       enableIfEnum: {x: 0.25, y: 0.75}
+      disableIfEnumFlag: {x: 0, y: 0}
+      disableIfEnumFlagMulti: {x: 0, y: 0}
 --- !u!1 &155697335
 GameObject:
   m_ObjectHideFlags: 0
@@ -277,6 +297,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1148579784}
   m_RootOrder: 9
@@ -325,6 +346,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1148579784}
   m_RootOrder: 27
@@ -373,6 +395,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1148579784}
   m_RootOrder: 30
@@ -394,6 +417,114 @@ MonoBehaviour:
     trans1: {fileID: 0}
     nest2:
       trans2: {fileID: 0}
+--- !u!1 &399707454
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 399707455}
+  - component: {fileID: 399707456}
+  m_Layer: 0
+  m_Name: SerializableTypes
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &399707455
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 399707454}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1148579784}
+  m_RootOrder: 33
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &399707456
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 399707454}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9368553f7002b2548be8781b3b4c6934, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Class:
+    ShowNestedMembers: 0
+    NestedClass:
+      ShowNestedMembers: 0
+      NestedClass:
+        ShowMembers: 0
+        Int1: 0
+        Float2: 0
+        String3: 
+      NestedStruct:
+        ShowMembers: 0
+        Int1: 0
+        Float2: 0
+        String3: 
+      NestedClassList: []
+      NestedStructList: []
+    NestedStruct:
+      ShowNestedMembers: 0
+      NestedClass:
+        ShowMembers: 0
+        Int1: 0
+        Float2: 0
+        String3: 
+      NestedStruct:
+        ShowMembers: 0
+        Int1: 0
+        Float2: 0
+        String3: 
+      NestedClassList: []
+      NestedStructList: []
+    NestedClassList: []
+    NestedStructList: []
+  Struct:
+    ShowNestedMembers: 0
+    NestedClass:
+      ShowNestedMembers: 0
+      NestedClass:
+        ShowMembers: 0
+        Int1: 0
+        Float2: 0
+        String3: 
+      NestedStruct:
+        ShowMembers: 0
+        Int1: 0
+        Float2: 0
+        String3: 
+      NestedClassList: []
+      NestedStructList: []
+    NestedStruct:
+      ShowNestedMembers: 0
+      NestedClass:
+        ShowMembers: 0
+        Int1: 0
+        Float2: 0
+        String3: 
+      NestedStruct:
+        ShowMembers: 0
+        Int1: 0
+        Float2: 0
+        String3: 
+      NestedClassList: []
+      NestedStructList: []
+    NestedClassList: []
+    NestedStructList: []
 --- !u!1 &572382748
 GameObject:
   m_ObjectHideFlags: 0
@@ -421,6 +552,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1148579784}
   m_RootOrder: 22
@@ -474,6 +606,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1148579784}
   m_RootOrder: 11
@@ -522,6 +655,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 2
@@ -538,8 +672,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9c928ea15ae74a44089beb2e534c1a35, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  layerName: Default
-  layerIndex: 4
 --- !u!1 &732714203
 GameObject:
   m_ObjectHideFlags: 0
@@ -566,6 +698,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1148579784}
   m_RootOrder: 20
@@ -597,6 +730,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1148579784}
   m_RootOrder: 4
@@ -645,6 +779,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1148579784}
   m_RootOrder: 15
@@ -693,6 +828,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1148579784}
   m_RootOrder: 16
@@ -745,6 +881,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1148579784}
   m_RootOrder: 12
@@ -795,6 +932,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1148579784}
   m_RootOrder: 10
@@ -846,6 +984,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1148579784}
   m_RootOrder: 7
@@ -893,6 +1032,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 106181863}
   - {fileID: 1178133860}
@@ -926,6 +1066,8 @@ Transform:
   - {fileID: 1706612702}
   - {fileID: 369789277}
   - {fileID: 1463483878}
+  - {fileID: 2026770417}
+  - {fileID: 399707455}
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -957,6 +1099,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1148579784}
   m_RootOrder: 1
@@ -986,7 +1129,7 @@ MonoBehaviour:
       name1: Trigger0
 --- !u!95 &1178133862
 Animator:
-  serializedVersion: 3
+  serializedVersion: 4
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -999,6 +1142,7 @@ Animator:
   m_UpdateMode: 0
   m_ApplyRootMotion: 0
   m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
@@ -1030,6 +1174,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1148579784}
   m_RootOrder: 18
@@ -1073,6 +1218,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1148579784}
   m_RootOrder: 14
@@ -1145,6 +1291,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1148579784}
   m_RootOrder: 25
@@ -1193,6 +1340,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1148579784}
   m_RootOrder: 19
@@ -1303,6 +1451,7 @@ Transform:
   m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
   m_LocalPosition: {x: 0, y: 3, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 1
@@ -1334,6 +1483,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1148579784}
   m_RootOrder: 31
@@ -1352,6 +1502,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   int0: 0
   nest1:
+    int1: 0
+    nest2:
+      int2: 0
+  inheritedNest:
     int1: 0
     nest2:
       int2: 0
@@ -1383,6 +1537,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1148579784}
   m_RootOrder: 24
@@ -1402,23 +1557,32 @@ MonoBehaviour:
   show1: 0
   show2: 0
   enum1: 0
+  enum2: 0
   showIfAll: 
   showIfAny: 
   showIfEnum: 
+  showIfEnumFlag: 
+  showIfEnumFlagMulti: 
   nest1:
     show1: 1
     show2: 0
     enum1: 0
+    enum2: 0
     showIfAll: 0
     showIfAny: 0
     showIfEnum: 0
+    showIfEnumFlag: 0
+    showIfEnumFlagMulti: 0
     nest2:
       show1: 1
       show2: 1
       enum1: 0
+      enum2: 0
       showIfAll: {x: 0.25, y: 0.75}
       showIfAny: {x: 0.25, y: 0.75}
       showIfEnum: {x: 0.25, y: 0.75}
+      showIfEnumFlag: {x: 0, y: 0}
+      showIfEnumFlagMulti: {x: 0, y: 0}
 --- !u!114 &1524906393
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1434,23 +1598,32 @@ MonoBehaviour:
   hide1: 0
   hide2: 0
   enum1: 0
+  enum2: 0
   hideIfAll: 
   hideIfAny: 
   hideIfEnum: 
+  hideIfEnumFlag: 
+  hideIfEnumFlagMulti: 
   nest1:
     hide1: 1
     hide2: 0
     enum1: 0
+    enum2: 0
     hideIfAll: 0
     hideIfAny: 0
     hideIfEnum: 0
+    hideIfEnumFlag: 0
+    hideIfEnumFlagMulti: 0
     nest2:
       hide1: 1
       hide2: 1
       enum1: 0
+      enum2: 0
       hideIfAll: {x: 0.25, y: 0.75}
       hideIfAny: {x: 0.25, y: 0.75}
       hideIfEnum: {x: 0.25, y: 0.75}
+      hideIfEnumFlag: {x: 0, y: 0}
+      hideIfEnumFlagMulti: {x: 0, y: 0}
 --- !u!1 &1552114399
 GameObject:
   m_ObjectHideFlags: 0
@@ -1478,6 +1651,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1148579784}
   m_RootOrder: 8
@@ -1587,6 +1761,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 1, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -1618,6 +1793,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1148579784}
   m_RootOrder: 6
@@ -1665,6 +1841,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1148579784}
   m_RootOrder: 28
@@ -1696,6 +1873,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1148579784}
   m_RootOrder: 29
@@ -1771,6 +1949,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1148579784}
   m_RootOrder: 13
@@ -1832,6 +2011,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1148579784}
   m_RootOrder: 21
@@ -1885,6 +2065,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1148579784}
   m_RootOrder: 26
@@ -1933,6 +2114,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1148579784}
   m_RootOrder: 17
@@ -1976,6 +2158,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1148579784}
   m_RootOrder: 5
@@ -1997,6 +2180,37 @@ MonoBehaviour:
     flags1: 6
     nest2:
       flags2: -1
+--- !u!1 &2026770416
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2026770417}
+  m_Layer: 0
+  m_Name: ===== Non-Unity Serialized Types =====
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2026770417
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2026770416}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1148579784}
+  m_RootOrder: 32
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2043059160
 GameObject:
   m_ObjectHideFlags: 0
@@ -2024,6 +2238,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1148579784}
   m_RootOrder: 2
@@ -2068,6 +2283,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1148579784}
   m_RootOrder: 3

--- a/Assets/NaughtyAttributes/Scripts/Editor/NaughtyPropertyDrawer.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/NaughtyPropertyDrawer.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using UnityEditor;
+using UnityEngine;
+
+namespace NaughtyAttributes.Editor
+{
+	[CustomPropertyDrawer(typeof(object), true)]
+	public class NaughtyPropertyDrawer : PropertyDrawer
+	{
+		public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+		{
+			if (!PropertyUtility.IsVisible(property))
+				return 0;
+
+			var handler = _ScriptAttributeUtility_GetPropertyHandler(property);
+
+			return _PropertyHandler_GetHeight(handler, property, label);
+		}
+
+		public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+		{
+			var includeChildren = _EditorGUI_HasVisibleChildFields(property, false);
+
+			NaughtyEditorGUI.PropertyField_Implementation(position, property, includeChildren,
+				(Rect position, SerializedProperty property, GUIContent label, bool includeChildren) =>
+				{
+					var handler = _ScriptAttributeUtility_GetPropertyHandler(property);
+
+					_PropertyHandler_OnGUI(handler, position, property, label, includeChildren);
+				});
+		}
+
+		const BindingFlags kAnyStaticMemberBindingFlags = BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic;
+
+		// UnityEditor.PropertyHandler is an internal type implementing default logic for many editor GUI operations
+		private static Type _PropertyHandlerType;
+
+		// UnityEditor.ScriptAttributeUtility allows us to retreive an instance of UnityEditor.PropertyHandler for a SerializedProperty
+		private static Type _ScriptAttributeUtilityType;
+
+		// This method returns an instance of PropertyHandler for a SerializedProperty
+		private static Func<SerializedProperty, object> _ScriptAttributeUtility_GetPropertyHandler;
+
+		// This method returns whether a serialized object has any visible child fields
+		// Unity passes result of this method down the line as value for the includeChildren parameters
+		private static Func<SerializedProperty, bool, bool> _EditorGUI_HasVisibleChildFields;
+
+		private static Func<object, SerializedProperty, GUIContent, float> _PropertyHandler_GetHeight;
+		private static Func<object, Rect, SerializedProperty, GUIContent, bool, bool> _PropertyHandler_OnGUI;
+
+		static NaughtyPropertyDrawer()
+		{
+			ResolveInternalUnityEditorTypes();
+			ResolveInternalUnityEditorMethods();
+		}
+
+		static void ResolveInternalUnityEditorTypes()
+		{
+			var unityEditorAssemblyTypes = typeof(UnityEditor.EditorGUI).Assembly.GetTypes();
+
+			_PropertyHandlerType = unityEditorAssemblyTypes.First(t => t.FullName == "UnityEditor.PropertyHandler");
+			_ScriptAttributeUtilityType = unityEditorAssemblyTypes.First(t => t.FullName == "UnityEditor.ScriptAttributeUtility");
+		}
+
+		static void ResolveInternalUnityEditorMethods()
+		{
+			_ScriptAttributeUtility_GetPropertyHandler = (Func<SerializedProperty, object>)
+				_ScriptAttributeUtilityType
+					.GetMethod("GetHandler", kAnyStaticMemberBindingFlags)
+					.CreateDelegate(typeof(Func<SerializedProperty, object>), null);
+
+			_EditorGUI_HasVisibleChildFields = (Func<SerializedProperty, bool, bool>)
+				typeof(EditorGUI)
+					.GetMethod("HasVisibleChildFields", kAnyStaticMemberBindingFlags)
+					.CreateDelegate(typeof(Func<SerializedProperty, bool, bool>), null);
+
+			Compile_PropertyHandler_GetHeight();
+			Compile_PropertyHandler_OnGUI();
+		}
+
+		static void Compile_PropertyHandler_GetHeight()
+		{
+			var paramHandler = Expression.Parameter(typeof(object));
+			var paramProperty = Expression.Parameter(typeof(SerializedProperty));
+			var paramLabel = Expression.Parameter(typeof(GUIContent));
+
+			var method =
+				_PropertyHandlerType
+					.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+					.First(m => m.Name == "GetHeight" && m.GetParameters().Length == 3);
+
+			_PropertyHandler_GetHeight =
+				Expression.Lambda<Func<object, SerializedProperty, GUIContent, float>>(
+					Expression.Call(
+						 Expression.TypeAs(paramHandler, _PropertyHandlerType), method,
+						paramProperty,
+						paramLabel,
+						Expression.Call(null, _EditorGUI_HasVisibleChildFields.Method, paramProperty, Expression.Constant(false))),
+					new[] { paramHandler, paramProperty, paramLabel })
+					.Compile();
+		}
+
+		static void Compile_PropertyHandler_OnGUI()
+		{
+			var paramHandler = Expression.Parameter(typeof(object));
+			var paramPosition = Expression.Parameter(typeof(Rect));
+			var paramProperty = Expression.Parameter(typeof(SerializedProperty));
+			var paramLabel = Expression.Parameter(typeof(GUIContent));
+			var paramIncludeChildren = Expression.Parameter(typeof(bool));
+
+			var method =
+				_PropertyHandlerType
+					.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+					.First(m => m.Name == "OnGUI" && m.GetParameters().Length == 4);
+
+			_PropertyHandler_OnGUI =
+				Expression.Lambda<Func<object, Rect, SerializedProperty, GUIContent, bool, bool>>(
+					Expression.Call(
+						 Expression.TypeAs(paramHandler, _PropertyHandlerType), method,
+						paramPosition,
+						paramProperty,
+						paramLabel,
+						paramIncludeChildren),
+					new[] { paramHandler, paramPosition, paramProperty, paramLabel, paramIncludeChildren })
+					.Compile();
+		}
+	}
+}

--- a/Assets/NaughtyAttributes/Scripts/Editor/NaughtyPropertyDrawer.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/NaughtyPropertyDrawer.cs
@@ -24,14 +24,16 @@ namespace NaughtyAttributes.Editor
 		{
 			var includeChildren = _EditorGUI_HasVisibleChildFields(property, false);
 
-			NaughtyEditorGUI.PropertyField_Implementation(position, property, includeChildren,
-				(Rect position, SerializedProperty property, GUIContent label, bool includeChildren) =>
-				{
-					var handler = _ScriptAttributeUtility_GetPropertyHandler(property);
-
-					_PropertyHandler_OnGUI(handler, position, property, label, includeChildren);
-				});
+			NaughtyEditorGUI.PropertyField_Implementation(position, property, includeChildren, DefaultOnGUI);
 		}
+
+		static void DefaultOnGUI(Rect position, SerializedProperty property, GUIContent label, bool includeChildren)
+		{
+			var handler = _ScriptAttributeUtility_GetPropertyHandler(property);
+
+			_PropertyHandler_OnGUI(handler, position, property, label, includeChildren);
+		}
+
 
 		const BindingFlags kAnyStaticMemberBindingFlags = BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic;
 

--- a/Assets/NaughtyAttributes/Scripts/Editor/NaughtyPropertyDrawer.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/NaughtyPropertyDrawer.cs
@@ -21,8 +21,12 @@ namespace NaughtyAttributes.Editor
 		}
 
 		public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
-		{
+		{		
+			#if UNITY_2021 || UNITY_2020
 			var includeChildren = _EditorGUI_HasVisibleChildFields(property, false);
+			#else
+			var includeChildren = _EditorGUI_HasVisibleChildFields(property);
+			#endif
 
 			NaughtyEditorGUI.PropertyField_Implementation(position, property, includeChildren, DefaultOnGUI);
 		}
@@ -36,19 +40,25 @@ namespace NaughtyAttributes.Editor
 
 
 		const BindingFlags kAnyStaticMemberBindingFlags = BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic;
+		const BindingFlags kAnyInstanceMemberBindingFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
 
 		// UnityEditor.PropertyHandler is an internal type implementing default logic for many editor GUI operations
 		private static Type _PropertyHandlerType;
-
+		
 		// UnityEditor.ScriptAttributeUtility allows us to retreive an instance of UnityEditor.PropertyHandler for a SerializedProperty
+		// This is what Unity calls
 		private static Type _ScriptAttributeUtilityType;
 
 		// This method returns an instance of PropertyHandler for a SerializedProperty
 		private static Func<SerializedProperty, object> _ScriptAttributeUtility_GetPropertyHandler;
-
+		
 		// This method returns whether a serialized object has any visible child fields
 		// Unity passes result of this method down the line as value for the includeChildren parameters
+		#if UNITY_2021 || UNITY_2020
 		private static Func<SerializedProperty, bool, bool> _EditorGUI_HasVisibleChildFields;
+		#else
+		private static Func<SerializedProperty, bool> _EditorGUI_HasVisibleChildFields;
+		#endif
 
 		private static Func<object, SerializedProperty, GUIContent, float> _PropertyHandler_GetHeight;
 		private static Func<object, Rect, SerializedProperty, GUIContent, bool, bool> _PropertyHandler_OnGUI;
@@ -57,6 +67,7 @@ namespace NaughtyAttributes.Editor
 		{
 			ResolveInternalUnityEditorTypes();
 			ResolveInternalUnityEditorMethods();
+			OverrideDefaultPropertyHandler();
 		}
 
 		static void ResolveInternalUnityEditorTypes()
@@ -74,13 +85,37 @@ namespace NaughtyAttributes.Editor
 					.GetMethod("GetHandler", kAnyStaticMemberBindingFlags)
 					.CreateDelegate(typeof(Func<SerializedProperty, object>), null);
 
+
+			#if UNITY_2021 || UNITY_2020
 			_EditorGUI_HasVisibleChildFields = (Func<SerializedProperty, bool, bool>)
 				typeof(EditorGUI)
 					.GetMethod("HasVisibleChildFields", kAnyStaticMemberBindingFlags)
 					.CreateDelegate(typeof(Func<SerializedProperty, bool, bool>), null);
+			#else
+			_EditorGUI_HasVisibleChildFields = (Func<SerializedProperty, bool>)
+				typeof(EditorGUI)
+					.GetMethod("HasVisibleChildFields", kAnyStaticMemberBindingFlags)
+					.CreateDelegate(typeof(Func<SerializedProperty, bool>), null);
+			#endif
+
 
 			Compile_PropertyHandler_GetHeight();
 			Compile_PropertyHandler_OnGUI();
+		}
+
+		static void OverrideDefaultPropertyHandler()
+		{
+			// For any type without an explicit property drawer, unity falls back to the '' PropertyHandler.
+			// PropertyHandler stores reference to a PropertyDrawer, which in the default handler is null.
+			// Overriding the default handler's drawer will make unity use our customised drawer for all types,
+			// without needing to attribute the type.
+			 
+			var ScriptAttributeUtility_sharedNullHandlerField = _ScriptAttributeUtilityType.GetField("s_SharedNullHandler", kAnyStaticMemberBindingFlags);
+			var PropertyHandler_m_PropertyDrawerField = _PropertyHandlerType.GetField("m_PropertyDrawer", kAnyInstanceMemberBindingFlags);
+
+			var sharedNullHandler = ScriptAttributeUtility_sharedNullHandlerField.GetValue(null);
+
+			PropertyHandler_m_PropertyDrawerField.SetValue(sharedNullHandler, new NaughtyPropertyDrawer());
 		}
 
 		static void Compile_PropertyHandler_GetHeight()
@@ -97,10 +132,14 @@ namespace NaughtyAttributes.Editor
 			_PropertyHandler_GetHeight =
 				Expression.Lambda<Func<object, SerializedProperty, GUIContent, float>>(
 					Expression.Call(
-						 Expression.TypeAs(paramHandler, _PropertyHandlerType), method,
+						Expression.TypeAs(paramHandler, _PropertyHandlerType), method,
 						paramProperty,
 						paramLabel,
+						#if UNITY_2021 || UNITY_2020
 						Expression.Call(null, _EditorGUI_HasVisibleChildFields.Method, paramProperty, Expression.Constant(false))),
+						#else
+						Expression.Call(null, _EditorGUI_HasVisibleChildFields.Method, paramProperty)),
+						#endif
 					new[] { paramHandler, paramProperty, paramLabel })
 					.Compile();
 		}

--- a/Assets/NaughtyAttributes/Scripts/Editor/NaughtyPropertyDrawer.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/NaughtyPropertyDrawer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -8,153 +9,239 @@ using UnityEngine;
 
 namespace NaughtyAttributes.Editor
 {
-	[CustomPropertyDrawer(typeof(object), true)]
-	public class NaughtyPropertyDrawer : PropertyDrawer
-	{
-		public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
-		{
-			if (PropertyUtility.GetTargetObjectWithProperty(property) != null)
-			{
-				if (!PropertyUtility.IsVisible(property))
-					return 0;
-			}
+    [InitializeOnLoad]
+    public class NaughtyPropertyDrawer : PropertyDrawer
+    {
+        public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+        {
+            if (PropertyUtility.GetTargetObjectWithProperty(property) != null)
+            {
+                if (!PropertyUtility.IsVisible(property))
+                    return 0;
+            }
 
-			var handler = _ScriptAttributeUtility_GetPropertyHandler(property);
+            var handler = _ScriptAttributeUtility_GetPropertyHandler(property);
 
-			return _PropertyHandler_GetHeight(handler, property, label);
-		}
+            return _PropertyHandler_GetHeight(handler, property, label);
+        }
 
-		public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
-		{		
-			if (PropertyUtility.GetTargetObjectWithProperty(property) == null)
-				DefaultOnGUI(position, property, label, true);
-			else
-				NaughtyEditorGUI.PropertyField_Implementation(position, property, true, DefaultOnGUI);
-		}
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            if (PropertyUtility.GetTargetObjectWithProperty(property) == null)
+            {
+                DefaultOnGUI(position, property, label, true);
+            }
+            else
+            {
+                NaughtyEditorGUI.PropertyField_Implementation(position, property, true, DefaultOnGUI);
+            }
+        }
 
-		static void DefaultOnGUI(Rect position, SerializedProperty property, GUIContent label, bool includeChildren)
-		{
-			var handler = _ScriptAttributeUtility_GetPropertyHandler(property);
+        static void DefaultOnGUI(Rect position, SerializedProperty property, GUIContent label, bool includeChildren)
+        {
+            var handler = _ScriptAttributeUtility_GetPropertyHandler(property);
 
-			_PropertyHandler_OnGUI(handler, position, property, label, includeChildren);
-		}
+            _PropertyHandler_OnGUI(handler, position, property, label, includeChildren);
+        }
 
 
-		const BindingFlags kAnyStaticMemberBindingFlags = BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic;
-		const BindingFlags kAnyInstanceMemberBindingFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+        const BindingFlags kAnyStaticMemberBindingFlags = BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic;
+        const BindingFlags kAnyInstanceMemberBindingFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
 
-		// UnityEditor.PropertyHandler is an internal type implementing default logic for many editor GUI operations
-		private static Type _PropertyHandlerType;
-		
-		// UnityEditor.ScriptAttributeUtility allows us to retreive an instance of UnityEditor.PropertyHandler for a SerializedProperty
-		// This is what Unity calls
-		private static Type _ScriptAttributeUtilityType;
+        // UnityEditor.PropertyHandler is an internal type implementing default logic for many editor GUI operations
+        private static Type _PropertyHandlerType;
 
-		// This method returns an instance of PropertyHandler for a SerializedProperty
-		private static Func<SerializedProperty, object> _ScriptAttributeUtility_GetPropertyHandler;
-		
-		private static Func<object, SerializedProperty, GUIContent, float> _PropertyHandler_GetHeight;
-		private static Func<object, Rect, SerializedProperty, GUIContent, bool, bool> _PropertyHandler_OnGUI;
+        // UnityEditor.ScriptAttributeUtility allows us to retreive an instance of UnityEditor.PropertyHandler for a SerializedProperty
+        // This is what Unity calls
+        private static Type _ScriptAttributeUtilityType;
 
-		static NaughtyPropertyDrawer()
-		{
-			ResolveInternalUnityEditorTypes();
-			ResolveInternalUnityEditorMethods();
-			OverrideDefaultPropertyHandler();
-		}
+        // This method returns an instance of PropertyHandler for a SerializedProperty
+        private static Func<SerializedProperty, object> _ScriptAttributeUtility_GetPropertyHandler;
 
-		static void ResolveInternalUnityEditorTypes()
-		{
-			var unityEditorAssemblyTypes = typeof(UnityEditor.EditorGUI).Assembly.GetTypes();
+        private static Func<object, SerializedProperty, GUIContent, float> _PropertyHandler_GetHeight;
+        private static Func<object, Rect, SerializedProperty, GUIContent, bool, bool> _PropertyHandler_OnGUI;
 
-			_PropertyHandlerType = unityEditorAssemblyTypes.First(t => t.FullName == "UnityEditor.PropertyHandler");
-			_ScriptAttributeUtilityType = unityEditorAssemblyTypes.First(t => t.FullName == "UnityEditor.ScriptAttributeUtility");
-		}
+        static NaughtyPropertyDrawer()
+        {
+            ResolveInternalUnityEditorTypes();
+            ResolveInternalUnityEditorMethods();
 
-		static void ResolveInternalUnityEditorMethods()
-		{
-			_ScriptAttributeUtility_GetPropertyHandler = (Func<SerializedProperty, object>)
-				_ScriptAttributeUtilityType
-					.GetMethod("GetHandler", kAnyStaticMemberBindingFlags)
-					.CreateDelegate(typeof(Func<SerializedProperty, object>), null);
+            SetFallbackPropertyDrawer();
+            HackDrawerTypeForTypeDictionary();
+        }
 
-			Compile_PropertyHandler_GetHeight();
-			Compile_PropertyHandler_OnGUI();
-		}
+        static void ResolveInternalUnityEditorTypes()
+        {
+            var unityEditorAssemblyTypes = typeof(UnityEditor.EditorGUI).Assembly.GetTypes();
 
-		static void OverrideDefaultPropertyHandler()
-		{
-			// For any type without an explicit property drawer, unity falls back to the '' PropertyHandler.
-			// PropertyHandler stores reference to a PropertyDrawer, which in the default handler is null.
-			// Overriding the default handler's drawer will make unity use our customised drawer for all types,
-			// without needing to attribute the type.
-			 
-			var ScriptAttributeUtility_sharedNullHandlerField = _ScriptAttributeUtilityType.GetField("s_SharedNullHandler", kAnyStaticMemberBindingFlags);
-			
-			var sharedNullHandler = ScriptAttributeUtility_sharedNullHandlerField.GetValue(null);
+            _PropertyHandlerType = unityEditorAssemblyTypes.First(t => t.FullName == "UnityEditor.PropertyHandler");
+            _ScriptAttributeUtilityType = unityEditorAssemblyTypes.First(t => t.FullName == "UnityEditor.ScriptAttributeUtility");
+        }
 
-			#if UNITY_2021
-			// In 2021, the handler uses a collection of drawers instead of a single drawer
-			// ScriptAttributeUtility.s_SharedNullHandler.m_PropertyDrawers
-			var PropertyHandler_m_PropertyDrawersField = _PropertyHandlerType.GetField("m_PropertyDrawers", kAnyInstanceMemberBindingFlags);
+        static void ResolveInternalUnityEditorMethods()
+        {
+            _ScriptAttributeUtility_GetPropertyHandler = (Func<SerializedProperty, object>)
+                _ScriptAttributeUtilityType
+                    .GetMethod("GetHandler", kAnyStaticMemberBindingFlags)
+                    .CreateDelegate(typeof(Func<SerializedProperty, object>), null);
 
-			var propertyDrawers = new List<PropertyDrawer> { new NaughtyPropertyDrawer() };
+            Compile_PropertyHandler_GetHeight();
+            Compile_PropertyHandler_OnGUI();
+        }
 
-			PropertyHandler_m_PropertyDrawersField.SetValue(sharedNullHandler, propertyDrawers);
-			#else
-			// ScriptAttributeUtility.s_SharedNullHandler.m_PropertyDrawer
-			var PropertyHandler_m_PropertyDrawerField = _PropertyHandlerType.GetField("m_PropertyDrawer", kAnyInstanceMemberBindingFlags);
+        static void SetFallbackPropertyDrawer()
+        {
+            // There is two 'hacks' to ensure Unity calls the NaughtyPropertyDrawer
+            // First - s_SharedNullHandler's property drawers are set to it - this is the fallback Unity uses.
+            // Second - the 'drawer resolver' dictionary is modified in a way, that for any type Unity has not got a custom drawer registered, it will fallback to NaughtyPropertyDrawer.
+            // Both appear necessary to handle all cases of Unity resolving drawers for any type (except the ones with explicit custom drawers).
 
-			PropertyHandler_m_PropertyDrawerField.SetValue(sharedNullHandler, new NaughtyPropertyDrawer());
-			#endif
+            var ScriptAttributeUtility_sharedNullHandlerField = _ScriptAttributeUtilityType.GetField("s_SharedNullHandler", kAnyStaticMemberBindingFlags);
 
-		}
+            var sharedNullHandler = ScriptAttributeUtility_sharedNullHandlerField.GetValue(null);
 
-		static void Compile_PropertyHandler_GetHeight()
-		{
-			var paramHandler = Expression.Parameter(typeof(object));
-			var paramProperty = Expression.Parameter(typeof(SerializedProperty));
-			var paramLabel = Expression.Parameter(typeof(GUIContent));
+#if UNITY_2021
+            // In 2021, the handler uses a collection of drawers instead of a single drawer
+            // ScriptAttributeUtility.s_SharedNullHandler.m_PropertyDrawers
+            var PropertyHandler_m_PropertyDrawersField = _PropertyHandlerType.GetField("m_PropertyDrawers", kAnyInstanceMemberBindingFlags);
 
-			var method =
-				_PropertyHandlerType
-					.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
-					.First(m => m.Name == "GetHeight" && m.GetParameters().Length == 3);
+            var propertyDrawers = new List<PropertyDrawer> { new NaughtyPropertyDrawer() };
 
-			_PropertyHandler_GetHeight =
-				Expression.Lambda<Func<object, SerializedProperty, GUIContent, float>>(
-					Expression.Call(
-						Expression.TypeAs(paramHandler, _PropertyHandlerType), method,
-						paramProperty,
-						paramLabel,
-						Expression.Constant(true)),
-					new[] { paramHandler, paramProperty, paramLabel })
-					.Compile();
-		}
+            PropertyHandler_m_PropertyDrawersField.SetValue(sharedNullHandler, propertyDrawers);
+#else
+            // ScriptAttributeUtility.s_SharedNullHandler.m_PropertyDrawer
+            var PropertyHandler_m_PropertyDrawerField = _PropertyHandlerType.GetField("m_PropertyDrawer", kAnyInstanceMemberBindingFlags);
 
-		static void Compile_PropertyHandler_OnGUI()
-		{
-			var paramHandler = Expression.Parameter(typeof(object));
-			var paramPosition = Expression.Parameter(typeof(Rect));
-			var paramProperty = Expression.Parameter(typeof(SerializedProperty));
-			var paramLabel = Expression.Parameter(typeof(GUIContent));
-			var paramIncludeChildren = Expression.Parameter(typeof(bool));
+            PropertyHandler_m_PropertyDrawerField.SetValue(sharedNullHandler, new NaughtyPropertyDrawer());
+#endif
+        }
 
-			var method =
-				_PropertyHandlerType
-					.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
-					.First(m => m.Name == "OnGUI" && m.GetParameters().Length == 4);
+        static void HackDrawerTypeForTypeDictionary()
+        {
+            // The hack works as follows:
+            // The dictionary's comparer is set to a special comparer that will:
+            //   for any type already present in the dictionary, perform standard comparision
+            //   for a type not present in the dictionary, fallback always to returning the '0' value, which returns the 'NaughtyPropertyDrawer' value
 
-			_PropertyHandler_OnGUI =
-				Expression.Lambda<Func<object, Rect, SerializedProperty, GUIContent, bool, bool>>(
-					Expression.Call(
-						 Expression.TypeAs(paramHandler, _PropertyHandlerType), method,
-						paramPosition,
-						paramProperty,
-						paramLabel,
-						paramIncludeChildren),
-					new[] { paramHandler, paramPosition, paramProperty, paramLabel, paramIncludeChildren })
-					.Compile();
-		}
-	}
+            // Invoke the initialization method, as the dictionary may not have yet been created
+            _ScriptAttributeUtilityType.GetMethod("BuildDrawerTypeForTypeDictionary", kAnyStaticMemberBindingFlags).Invoke(null, Array.Empty<object>());
+
+            // Get the dictionary field, and value
+            var ScriptAttributeUtility_s_DrawerTypeForTypeField = _ScriptAttributeUtilityType.GetField("s_DrawerTypeForType", kAnyStaticMemberBindingFlags);
+            var drawerTypeForTypeDict = (IDictionary) ScriptAttributeUtility_s_DrawerTypeForTypeField.GetValue(null);
+
+            // Resolve the 'value' type from the dictionary and its fields
+            var drawerKeySetType = _ScriptAttributeUtilityType.GetNestedType("DrawerKeySet", BindingFlags.NonPublic);
+            var drawerKeySet_drawerField = drawerKeySetType.GetField("drawer"); // drawer is type of the property drawer
+            var drawerKeySet_typeField = drawerKeySetType.GetField("type"); // type is the handled type
+
+            // Store all handled types in a hash set, for fast lookup in the comparer
+            // Unity should populate the dictionary with all possible types, including derived types for 'base' drawers
+            var handledTypes = new HashSet<Type>();
+
+            foreach (var value in drawerTypeForTypeDict.Values)
+            {
+                var type = (Type) drawerKeySet_typeField.GetValue(value);
+
+                handledTypes.Add(type);
+            }
+
+            var dictType = drawerTypeForTypeDict.GetType();
+
+            // Resolve the internal comparer field
+            var comparerField =
+                dictType.GetField("comparer", kAnyInstanceMemberBindingFlags) // .NET Framework
+                ?? dictType.GetField("_comparer", kAnyInstanceMemberBindingFlags); // .NET Standard
+
+            // Set the comparer to our faker
+            comparerField.SetValue(drawerTypeForTypeDict, new FallbackToNaughtyPropertyDrawerComparer(handledTypes));
+
+            // Finally, add the indicator type to the dictionary
+            var drawerKeySetInstance = Activator.CreateInstance(drawerKeySetType);
+            drawerKeySet_drawerField.SetValue(drawerKeySetInstance, typeof(NaughtyPropertyDrawer));
+            drawerKeySet_typeField.SetValue(drawerKeySetInstance, typeof(FallbackIndicatorType));
+            drawerTypeForTypeDict[typeof(FallbackIndicatorType)] = drawerKeySetInstance;
+        }
+
+        // This is used as an indicator, so the comparer knows when we are faking the result
+        class FallbackIndicatorType
+        { }
+
+        class FallbackToNaughtyPropertyDrawerComparer : IEqualityComparer<Type>
+        {
+            HashSet<Type> _handledTypes;
+
+            public FallbackToNaughtyPropertyDrawerComparer(HashSet<Type> handledTypes)
+            {
+                _handledTypes = handledTypes;
+            }
+
+            public bool Equals(Type x, Type y)
+            {
+                if (x == typeof(FallbackIndicatorType) || y == typeof(FallbackIndicatorType))
+                    return true;
+
+                return x == y;
+            }
+
+            public int GetHashCode(Type obj)
+            {
+                if (obj != typeof(FallbackIndicatorType))
+                {
+                    if (_handledTypes.Contains(obj))
+                        return obj.GetHashCode();
+                }
+
+                // 0 means fake result
+                return 0;
+            }
+        }
+
+        static void Compile_PropertyHandler_GetHeight()
+        {
+            var paramHandler = Expression.Parameter(typeof(object));
+            var paramProperty = Expression.Parameter(typeof(SerializedProperty));
+            var paramLabel = Expression.Parameter(typeof(GUIContent));
+
+            var method =
+                _PropertyHandlerType
+                    .GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+                    .First(m => m.Name == "GetHeight" && m.GetParameters().Length == 3);
+
+            _PropertyHandler_GetHeight =
+                Expression.Lambda<Func<object, SerializedProperty, GUIContent, float>>(
+                    Expression.Call(
+                        Expression.TypeAs(paramHandler, _PropertyHandlerType), method,
+                        paramProperty,
+                        paramLabel,
+                        Expression.Constant(true)),
+                    new[] { paramHandler, paramProperty, paramLabel })
+                    .Compile();
+        }
+
+        static void Compile_PropertyHandler_OnGUI()
+        {
+            var paramHandler = Expression.Parameter(typeof(object));
+            var paramPosition = Expression.Parameter(typeof(Rect));
+            var paramProperty = Expression.Parameter(typeof(SerializedProperty));
+            var paramLabel = Expression.Parameter(typeof(GUIContent));
+            var paramIncludeChildren = Expression.Parameter(typeof(bool));
+
+            var method =
+                _PropertyHandlerType
+                    .GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+                    .First(m => m.Name == "OnGUI" && m.GetParameters().Length == 4);
+
+            _PropertyHandler_OnGUI =
+                Expression.Lambda<Func<object, Rect, SerializedProperty, GUIContent, bool, bool>>(
+                    Expression.Call(
+                         Expression.TypeAs(paramHandler, _PropertyHandlerType), method,
+                        paramPosition,
+                        paramProperty,
+                        paramLabel,
+                        paramIncludeChildren),
+                    new[] { paramHandler, paramPosition, paramProperty, paramLabel, paramIncludeChildren })
+                    .Compile();
+        }
+    }
 }

--- a/Assets/NaughtyAttributes/Scripts/Editor/NaughtyPropertyDrawer.cs.meta
+++ b/Assets/NaughtyAttributes/Scripts/Editor/NaughtyPropertyDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 13f950b237e298749b867d407d427de0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/NaughtyAttributes/Scripts/Editor/Utility/NaughtyEditorGUI.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/Utility/NaughtyEditorGUI.cs
@@ -16,7 +16,7 @@ namespace NaughtyAttributes.Editor
 
 		private static GUIStyle _buttonStyle = new GUIStyle(GUI.skin.button) { richText = true };
 
-		private delegate void PropertyFieldFunction(Rect rect, SerializedProperty property, GUIContent label, bool includeChildren);
+		public delegate void PropertyFieldFunction(Rect rect, SerializedProperty property, GUIContent label, bool includeChildren);
 
 		public static void PropertyField(Rect rect, SerializedProperty property, bool includeChildren)
 		{
@@ -39,7 +39,7 @@ namespace NaughtyAttributes.Editor
 			EditorGUILayout.PropertyField(property, label, includeChildren);
 		}
 
-		private static void PropertyField_Implementation(Rect rect, SerializedProperty property, bool includeChildren, PropertyFieldFunction propertyFieldFunction)
+		public static void PropertyField_Implementation(Rect rect, SerializedProperty property, bool includeChildren, PropertyFieldFunction propertyFieldFunction)
 		{
 			SpecialCaseDrawerAttribute specialCaseAttribute = PropertyUtility.GetAttribute<SpecialCaseDrawerAttribute>(property);
 			if (specialCaseAttribute != null)

--- a/Assets/NaughtyAttributes/Scripts/Test/SerializableTypesTest.cs
+++ b/Assets/NaughtyAttributes/Scripts/Test/SerializableTypesTest.cs
@@ -1,0 +1,114 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace NaughtyAttributes.Test
+{
+	public class SerializableTypesTest : MonoBehaviour
+	{
+		public ClassType Class;
+		public StructType Struct;
+
+		[System.Serializable]
+		public class ClassType
+		{
+			public bool ShowNestedMembers;
+
+			[ShowIf("ShowNestedMembers")]
+			public NestedClassType NestedClass;
+
+			[ShowIf("ShowNestedMembers")]
+			public NestedStructType NestedStruct;
+
+			[ShowIf("ShowNestedMembers")]
+			public List<NestedClassType> NestedClassList;
+
+			[ShowIf("ShowNestedMembers")]
+			public List<NestedStructType> NestedStructList;
+		}
+
+		[System.Serializable]
+		public struct StructType
+		{
+			public bool ShowNestedMembers;
+
+			[ShowIf("ShowNestedMembers")]
+			public NestedClassType NestedClass;
+
+			[ShowIf("ShowNestedMembers")]
+			public NestedStructType NestedStruct;
+
+			[ShowIf("ShowNestedMembers")]
+			public List<NestedClassType> NestedClassList;
+
+			[ShowIf("ShowNestedMembers")]
+			public List<NestedStructType> NestedStructList;
+		}
+
+		[System.Serializable]
+		public class NestedClassType
+		{
+			public bool ShowNestedMembers;
+
+			[ShowIf("ShowNestedMembers")]
+			public NestedClassType2 NestedClass;
+
+			[ShowIf("ShowNestedMembers")]
+			public NestedStructType2 NestedStruct;
+
+			[ShowIf("ShowNestedMembers")]
+			public List<NestedClassType2> NestedClassList;
+
+			[ShowIf("ShowNestedMembers")]
+			public List<NestedStructType2> NestedStructList;
+		}
+
+		[System.Serializable]
+		public struct NestedStructType
+		{
+			public bool ShowNestedMembers;
+
+			[ShowIf("ShowNestedMembers")]
+			public NestedClassType2 NestedClass;
+
+			[ShowIf("ShowNestedMembers")]
+			public NestedStructType2 NestedStruct;
+
+			[ShowIf("ShowNestedMembers")]
+			public List<NestedClassType2> NestedClassList;
+
+			[ShowIf("ShowNestedMembers")]
+			public List<NestedStructType2> NestedStructList;
+		}
+
+		[System.Serializable]
+		public class NestedClassType2
+		{
+			public bool ShowMembers;
+
+			[ShowIf("ShowMembers")]
+			public int Int1;
+
+			[ShowIf("ShowMembers")]
+			public float Float2;
+
+			[ShowIf("ShowMembers")]
+			public string String3;
+		}
+
+		[System.Serializable]
+		public struct NestedStructType2
+		{
+			public bool ShowMembers;
+
+			[ShowIf("ShowMembers")]
+			public int Int1;
+
+			[ShowIf("ShowMembers")]
+			public float Float2;
+
+			[ShowIf("ShowMembers")]
+			public string String3;
+		}
+	}
+}

--- a/Assets/NaughtyAttributes/Scripts/Test/SerializableTypesTest.cs.meta
+++ b/Assets/NaughtyAttributes/Scripts/Test/SerializableTypesTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9368553f7002b2548be8781b3b4c6934
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This PR adds implementation that allows serializable types not derived from `UnityEngine.Object` to utilise NaughtyAttribute's customization.

The result is that any type attributed with `[Serializable]` (that Unity can handle) should support NaughtyAttributes customization on its fields. This includes any form of nesting (direct, or list). 

This is limited to meta attributes only - because the method is invoked per serialized property, rather than the object itself.

**Implementation details:**
Added a new property drawer type: `NaughtyPropertyDrawer`.  
It is injected into Unity's internals, so it can used as the default/fallback property drawer for any properties not handled by another drawer.  

The drawer implements two methods: `GetPropertyHeight` and `OnGUI`.   
Both are implemented to take into account NaughtyAttribute's customization, followed by invocation of Unity's original logic.  

The Unity's original logic is available through the internal `UnityEditor.PropertyHandler` type.
An instance of `PropertyHandler` is resolved using the internal static method `UnityEditor.ScriptAttributeUtility.GetHandler(ScriptableProperty)`.  

All internals and injections are done in the type's static constructor, triggered by `[InitializeOnLoad]`.  
Method calls to Unity's internals are compiled.  

Modified the `NaughtyEditorGUI` class:  
The `PropertyField_Implementation` method has been made public, as it is used from within the `NaughtyPropertyDrawer.OnGUI` method.  

I tested whether the implementation works as expected on the following Unity versions:
`2021.2.0b1`
`2021.1.13f1`
`2020.3.13f1`
`2019.4.28f1`

**Notes**
An alternative approach would be to register such a custom drawer for every type in the AppDomain.
From my tests - this does not work well with nested properties - which is what the 'fallback' drawer injection resolves.
It also would cause UI lag when an inspector is drawn - due to the size of the drawer resolution dictionary - which is why I use a hack with custom comparer injected into the dictionary. 

This is my first attempt at a contribution, so if this should be done differently, lemme know.
