### PR TITLE
Added 'writable' parameter to the Expandable attribute

### DIFF
--- a/Assets/NaughtyAttributes/Scripts/Core/DrawerAttributes/Expandable.cs
+++ b/Assets/NaughtyAttributes/Scripts/Core/DrawerAttributes/Expandable.cs
@@ -5,5 +5,10 @@ namespace NaughtyAttributes
 	[AttributeUsage(AttributeTargets.Field, AllowMultiple = false, Inherited = true)]
 	public class ExpandableAttribute : DrawerAttribute
 	{
+		public readonly bool IsWritable;
+		public ExpandableAttribute(bool writable = true)
+		{
+			IsWritable = writable;
+		}
 	}
 }

--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/ExpandablePropertyDrawer.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/ExpandablePropertyDrawer.cs
@@ -115,7 +115,10 @@ namespace NaughtyAttributes.Editor
 						// Draw the child properties
 						if (property.isExpanded)
 						{
+							ExpandableAttribute attr = (ExpandableAttribute)attribute;
+							GUI.enabled = attr.IsWritable;
 							DrawChildProperties(rect, property);
+							GUI.enabled = true;
 						}
 					}
 				}


### PR DESCRIPTION
Sometimes it's convenient to have expandable scripatable object as read only 