### PR TITLE
Feature/anim controller reader attribute

### DIFF
--- a/Assets/NaughtyAttributes/Samples/DemoScene/DemoScene.unity
+++ b/Assets/NaughtyAttributes/Samples/DemoScene/DemoScene.unity
@@ -513,6 +513,262 @@ MonoBehaviour:
     minMaxSlider1: {x: 0.25, y: 0.75}
     nest2:
       minMaxSlider2: {x: 6, y: 11}
+--- !u!1 &645779700
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 645779701}
+  - component: {fileID: 645779702}
+  m_Layer: 0
+  m_Name: HugeMixPerformanceTest
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &645779701
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 645779700}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1148579784}
+  m_RootOrder: 33
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &645779702
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 645779700}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9d0844cc6e62fe54393612902562c4e2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  animator0: {fileID: 1178133862}
+  hash0: -392453409
+  name0: Float1
+  animatorParamNest1:
+    animator1: {fileID: 1178133862}
+    hash1: 726565755
+    name1: Float1
+    nest2:
+      animator2: {fileID: 1178133862}
+      hash1: 0
+      name1: Trigger0
+  int0: 25
+  int1: 0
+  float0: 0
+  float1: 0
+  slider0: {x: 0, y: 0}
+  slider1: {x: 0, y: 0}
+  str0: dfgdfg
+  str1: 
+  trans0: {fileID: 0}
+  trans1: {fileID: 0}
+  myInt: 15
+  curve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: -1
+      value: -1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    - serializedVersion: 3
+      time: 1
+      value: 1
+      inSlope: 2
+      outSlope: 2
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  curve1:
+    serializedVersion: 2
+    m_Curve: []
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  curve2:
+    serializedVersion: 2
+    m_Curve: []
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  curveRangeNest1:
+    curve:
+      serializedVersion: 2
+      m_Curve: []
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    curveRangeNest2:
+      curve:
+        serializedVersion: 2
+        m_Curve: []
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+  disableIf1: 0
+  disableIf2: 0
+  disableIfEnum1: 2
+  disableIfEnum2: 0
+  disableIfAll: 
+  disableIfAny: 
+  disableIfEnum: 
+  disableIfEnumFlag: 
+  disableIfEnumFlagMulti: 
+  disableIfNest1:
+    disable1: 0
+    disable2: 0
+    enum1: 0
+    enum2: 0
+    disableIfAll: 1
+    disableIfAny: 2
+    disableIfEnum: 3
+    disableIfEnumFlag: 0
+    disableIfEnumFlagMulti: 0
+    nest2:
+      disable1: 0
+      disable2: 0
+      enum1: 0
+      enum2: 0
+      enableIfAll: {x: 0.25, y: 0.75}
+      enableIfAny: {x: 0.25, y: 0.75}
+      enableIfEnum: {x: 0.25, y: 0.75}
+      disableIfEnumFlag: {x: 0, y: 0}
+      disableIfEnumFlagMulti: {x: 0, y: 0}
+  dropDownIntValue: 1
+  dropdownNest1:
+    stringValue: 
+    nest2:
+      vectorValue: {x: 0, y: 0, z: 0}
+  enable1: 0
+  enable2: 0
+  enableIfEnum1: 0
+  enableIfEnum2: 0
+  enableIfAll: 
+  enableIfAny: 
+  enableIfEnum: 
+  enableIfEnumFlag: 
+  enableIfEnumFlagMulti: 
+  enableIfNest1:
+    enable1: 0
+    enable2: 0
+    enum1: 0
+    enum2: 0
+    enableIfAll: 0
+    enableIfAny: 0
+    enableIfEnum: 0
+    enableIfEnumFlag: 0
+    enableIfEnumFlagMulti: 0
+    nest2:
+      enable1: 0
+      enable2: 0
+      enum1: 0
+      enum2: 0
+      enableIfAll: {x: 0.25, y: 0.75}
+      enableIfAny: {x: 0.25, y: 0.75}
+      enableIfEnum: {x: 0.25, y: 0.75}
+      enableIfEnumFlag: {x: 0, y: 0}
+      enableIfEnumFlagMulti: {x: 0, y: 0}
+  enumFlagsTest0: 0
+  enumFlagsNest1:
+    flags1: 0
+    nest2:
+      flags2: 0
+  obj0: {fileID: 0}
+  expandableScriptableObjectNest1:
+    obj1: {fileID: 0}
+    nest2:
+      obj2: {fileID: 0}
+  foldoutTestInt0: 27
+  foldoutTestInt1: 0
+  foldoutTestFloat0: 0
+  foldoutTestFloat1: 0
+  foldoutTestSlider0: {x: 0, y: 0.46343613}
+  foldoutTestSlider1: {x: 0, y: 1}
+  foldoutTestStr0: 
+  foldoutTestStr1: 
+  foldoutTestTrans0: {fileID: 0}
+  foldoutTestTrans1: {fileID: 0}
+  hide1: 0
+  hide2: 0
+  hideIfEnum1: 0
+  hideIfEnum2: 0
+  hideIfAll: 
+  hideIfAny: 
+  hideIfEnum: 
+  hideIfEnumFlag: 
+  hideIfEnumFlagMulti: 
+  hideIfNest1:
+    hide1: 0
+    hide2: 0
+    enum1: 0
+    enum2: 0
+    hideIfAll: 0
+    hideIfAny: 0
+    hideIfEnum: 0
+    hideIfEnumFlag: 0
+    hideIfEnumFlagMulti: 0
+    nest2:
+      hide1: 0
+      hide2: 0
+      enum1: 0
+      enum2: 0
+      hideIfAll: {x: 0.25, y: 0.75}
+      hideIfAny: {x: 0.25, y: 0.75}
+      hideIfEnum: {x: 0.25, y: 0.75}
+      hideIfEnumFlag: {x: 0, y: 0}
+      hideIfEnumFlagMulti: {x: 0, y: 0}
+  showIf1: 0
+  showIf2: 0
+  showIfEnum1: 0
+  showIfEnum2: 0
+  showIfAll: 
+  showIfAny: 
+  showIfEnum: 
+  showIfEnumFlag: 
+  showIfEnumFlagMulti: 
+  showIfNest1:
+    show1: 0
+    show2: 0
+    enum1: 0
+    enum2: 0
+    showIfAll: 0
+    showIfAny: 0
+    showIfEnum: 0
+    showIfEnumFlag: 0
+    showIfEnumFlagMulti: 0
+    nest2:
+      show1: 0
+      show2: 0
+      enum1: 0
+      enum2: 0
+      showIfAll: {x: 0.25, y: 0.75}
+      showIfAny: {x: 0.25, y: 0.75}
+      showIfEnum: {x: 0.25, y: 0.75}
+      showIfEnumFlag: {x: 0, y: 0}
+      showIfEnumFlagMulti: {x: 0, y: 0}
 --- !u!1 &706445688
 GameObject:
   m_ObjectHideFlags: 0
@@ -943,6 +1199,7 @@ Transform:
   - {fileID: 369789277}
   - {fileID: 1463483878}
   - {fileID: 1468344835}
+  - {fileID: 645779701}
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/NaughtyAttributes/Samples/DemoScene/DemoScene.unity
+++ b/Assets/NaughtyAttributes/Samples/DemoScene/DemoScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657874, g: 0.49641258, b: 0.5748172, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -201,23 +201,32 @@ MonoBehaviour:
   enable1: 0
   enable2: 0
   enum1: 0
+  enum2: 0
   enableIfAll: 
   enableIfAny: 
   enableIfEnum: 
+  enableIfEnumFlag: 
+  enableIfEnumFlagMulti: 
   nest1:
     enable1: 1
     enable2: 0
     enum1: 0
+    enum2: 0
     enableIfAll: 1
     enableIfAny: 2
     enableIfEnum: 0
+    enableIfEnumFlag: 0
+    enableIfEnumFlagMulti: 0
     nest2:
       enable1: 1
       enable2: 1
       enum1: 0
+      enum2: 0
       enableIfAll: {x: 0.25, y: 0.75}
       enableIfAny: {x: 0.25, y: 0.75}
       enableIfEnum: {x: 0.25, y: 0.75}
+      enableIfEnumFlag: {x: 0, y: 0}
+      enableIfEnumFlagMulti: {x: 0, y: 0}
 --- !u!114 &114650326
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -233,23 +242,32 @@ MonoBehaviour:
   disable1: 0
   disable2: 0
   enum1: 0
+  enum2: 0
   disableIfAll: 
   disableIfAny: 
   disableIfEnum: 
+  disableIfEnumFlag: 
+  disableIfEnumFlagMulti: 
   nest1:
     disable1: 1
     disable2: 0
     enum1: 0
+    enum2: 0
     disableIfAll: 1
     disableIfAny: 2
     disableIfEnum: 3
+    disableIfEnumFlag: 0
+    disableIfEnumFlagMulti: 0
     nest2:
       disable1: 1
       disable2: 1
       enum1: 0
+      enum2: 0
       enableIfAll: {x: 0.25, y: 0.75}
       enableIfAny: {x: 0.25, y: 0.75}
       enableIfEnum: {x: 0.25, y: 0.75}
+      disableIfEnumFlag: {x: 0, y: 0}
+      disableIfEnumFlagMulti: {x: 0, y: 0}
 --- !u!1 &155697335
 GameObject:
   m_ObjectHideFlags: 0
@@ -538,8 +556,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9c928ea15ae74a44089beb2e534c1a35, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  layerName: Default
-  layerIndex: 4
 --- !u!1 &732714203
 GameObject:
   m_ObjectHideFlags: 0
@@ -926,6 +942,7 @@ Transform:
   - {fileID: 1706612702}
   - {fileID: 369789277}
   - {fileID: 1463483878}
+  - {fileID: 1468344835}
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1355,6 +1372,40 @@ MonoBehaviour:
     int1: 0
     nest2:
       int2: 0
+  inheritedNest:
+    int1: 0
+    nest2:
+      int2: 0
+--- !u!1 &1468344834
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1468344835}
+  m_Layer: 0
+  m_Name: ===== Mixxed Attributes =====
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1468344835
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1468344834}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1148579784}
+  m_RootOrder: 32
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1524906390
 GameObject:
   m_ObjectHideFlags: 0
@@ -1402,23 +1453,32 @@ MonoBehaviour:
   show1: 0
   show2: 0
   enum1: 0
+  enum2: 0
   showIfAll: 
   showIfAny: 
   showIfEnum: 
+  showIfEnumFlag: 
+  showIfEnumFlagMulti: 
   nest1:
     show1: 1
     show2: 0
     enum1: 0
+    enum2: 0
     showIfAll: 0
     showIfAny: 0
     showIfEnum: 0
+    showIfEnumFlag: 0
+    showIfEnumFlagMulti: 0
     nest2:
       show1: 1
       show2: 1
       enum1: 0
+      enum2: 0
       showIfAll: {x: 0.25, y: 0.75}
       showIfAny: {x: 0.25, y: 0.75}
       showIfEnum: {x: 0.25, y: 0.75}
+      showIfEnumFlag: {x: 0, y: 0}
+      showIfEnumFlagMulti: {x: 0, y: 0}
 --- !u!114 &1524906393
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1434,23 +1494,32 @@ MonoBehaviour:
   hide1: 0
   hide2: 0
   enum1: 0
+  enum2: 0
   hideIfAll: 
   hideIfAny: 
   hideIfEnum: 
+  hideIfEnumFlag: 
+  hideIfEnumFlagMulti: 
   nest1:
     hide1: 1
     hide2: 0
     enum1: 0
+    enum2: 0
     hideIfAll: 0
     hideIfAny: 0
     hideIfEnum: 0
+    hideIfEnumFlag: 0
+    hideIfEnumFlagMulti: 0
     nest2:
       hide1: 1
       hide2: 1
       enum1: 0
+      enum2: 0
       hideIfAll: {x: 0.25, y: 0.75}
       hideIfAny: {x: 0.25, y: 0.75}
       hideIfEnum: {x: 0.25, y: 0.75}
+      hideIfEnumFlag: {x: 0, y: 0}
+      hideIfEnumFlagMulti: {x: 0, y: 0}
 --- !u!1 &1552114399
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/NaughtyAttributes/Samples/DemoScene/DemoScene.unity
+++ b/Assets/NaughtyAttributes/Samples/DemoScene/DemoScene.unity
@@ -200,8 +200,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   enable1: 0
   enable2: 0
-  enum1: 0
-  enum2: 0
+  enum1: 2
+  enum2: 3
   enableIfAll: 
   enableIfAny: 
   enableIfEnum: 
@@ -311,11 +311,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e0cc8a31c22090847b75538c0ed2d2fc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  inputAxis0: 
+  inputAxis0: Fire1
   nest1:
-    inputAxis1: Horizontal
+    inputAxis1: Vertical
     nest2:
-      inputAxis2: Vertical
+      inputAxis2: Fire2
 --- !u!1 &237121640
 GameObject:
   m_ObjectHideFlags: 0
@@ -508,9 +508,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fd67fbde6acdd6a44944f12e507067c5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  minMaxSlider0: {x: 0, y: 0.5}
+  minMaxSlider0: {x: 0.10512249, y: 0.5}
   nest1:
-    minMaxSlider1: {x: 0.25, y: 0.75}
+    minMaxSlider1: {x: 0.25, y: 0.5771715}
     nest2:
       minMaxSlider2: {x: 6, y: 11}
 --- !u!1 &645779700
@@ -577,7 +577,7 @@ MonoBehaviour:
   str1: 
   trans0: {fileID: 0}
   trans1: {fileID: 0}
-  myInt: 15
+  myInt: 13
   curve:
     serializedVersion: 2
     m_Curve:
@@ -1039,7 +1039,7 @@ MonoBehaviour:
     nest2:
       stamina: 75
   elixir: 50
-  maxElixir: 100
+  maxElixir: 71
 --- !u!1 &993534225
 GameObject:
   m_ObjectHideFlags: 0
@@ -1483,9 +1483,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8bcc0d5613b48fb43bd36c9d37e99900, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  tag0: 
+  tag0: Finish
   nest1:
-    tag1: MainCamera
+    tag1: EditorOnly
     nest2:
       tag2: Player
 --- !u!1 &1444377589
@@ -1624,7 +1624,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 94adafcfe59aa344c9b5596b2cc6ecd0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  int0: 0
+  int0: 2
   nest1:
     int1: 0
     nest2:
@@ -1820,11 +1820,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0dcb08e489c17644e9eacaa1ec5fe781, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  normal: 0
+  normal: 37
   nest1:
-    warning: 0
+    warning: 37
     nest2:
-      error: 0
+      error: 70
 --- !u!1 &1591883662
 GameObject:
   m_ObjectHideFlags: 0
@@ -2113,22 +2113,24 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c93fde7cd79390148ac576c3a159a77b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  intArray: 020000000300000001000000
+  intArray: 010000000300000002000000
   vectorList:
-  - {x: 2, y: 2, z: 2}
   - {x: 3, y: 3, z: 3}
+  - {x: 2, y: 2, z: 2}
   - {x: 1, y: 1, z: 1}
   structList:
-  - Int: 2
-    Float: 2
-    Vector: {x: 2, y: 2, z: 2}
   - Int: 3
     Float: 3
     Vector: {x: 3, y: 3, z: 3}
   - Int: 1
-    Float: 1
+    Float: 1.96
     Vector: {x: 1, y: 1, z: 1}
-  gameObjectsList: []
+  - Int: 2
+    Float: 2
+    Vector: {x: 2, y: 2, z: 2}
+  gameObjectsList:
+  - {fileID: 0}
+  - {fileID: 0}
   transformsList: []
   monoBehavioursList: []
 --- !u!1 &1784643784
@@ -2174,13 +2176,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3920f5ea384951b4990e4d9e8032d12e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  int0: 0
+  int0: 27
   int1: 0
-  float0: 0
+  float0: 2.23
   float1: 0
-  slider0: {x: 0.25, y: 0.75}
+  slider0: {x: 0.33104458, y: 0.75}
   slider1: {x: 0.25, y: 0.75}
-  str0: 
+  str0: gg
   str1: 
   trans0: {fileID: 0}
   trans1: {fileID: 0}

--- a/Assets/NaughtyAttributes/Samples/DemoScene/DemoScene.unity
+++ b/Assets/NaughtyAttributes/Samples/DemoScene/DemoScene.unity
@@ -561,12 +561,18 @@ MonoBehaviour:
   name0: Float1
   animatorParamNest1:
     animator1: {fileID: 1178133862}
+    animatorController1: {fileID: 0}
     hash1: 726565755
     name1: Float1
+    hashController1: 0
+    nameController1: 
     nest2:
       animator2: {fileID: 1178133862}
+      animatorController2: {fileID: 0}
       hash1: 0
       name1: Trigger0
+      hashController2: 0
+      nameController2: 
   int0: 25
   int1: 0
   float0: 0
@@ -1248,16 +1254,27 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   animator0: {fileID: 1178133862}
-  hash0: 1943738498
+  animatorController0: {fileID: 9100000, guid: 63ee86efd213bf34285c95f33e79dc6c, type: 2}
+  hash0: -392453409
   name0: Float0
+  hashController0: 726565755
+  nameController0: Trigger1
   nest1:
     animator1: {fileID: 1178133862}
-    hash1: 726565755
+    animatorController1: {fileID: 9100000, guid: 63ee86efd213bf34285c95f33e79dc6c,
+      type: 2}
+    hash1: 1548334061
     name1: Float0
+    hashController1: 1548334061
+    nameController1: Float1
     nest2:
       animator2: {fileID: 1178133862}
+      animatorController2: {fileID: 9100000, guid: 63ee86efd213bf34285c95f33e79dc6c,
+        type: 2}
       hash1: -392453409
       name1: Trigger0
+      hashController2: -392453409
+      nameController2: Trigger1
 --- !u!95 &1178133862
 Animator:
   serializedVersion: 3

--- a/Assets/NaughtyAttributes/Samples/DemoScene/TestAssets/NaughtyScriptableObject.asset
+++ b/Assets/NaughtyAttributes/Samples/DemoScene/TestAssets/NaughtyScriptableObject.asset
@@ -16,3 +16,6 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 149474eb879a6a641b560ca17d48712f, type: 2}
   - {fileID: 11400000, guid: ca97c330d5c96794aa4df848d63f836b, type: 2}
   - {fileID: 0}
+  animatorController0: {fileID: 9100000, guid: 63ee86efd213bf34285c95f33e79dc6c, type: 2}
+  hashController0: -392453409
+  nameController0: Trigger1

--- a/Assets/NaughtyAttributes/Scripts/Editor/NaughtyInspector.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/NaughtyInspector.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System;
 using System.Linq;
 using System.Reflection;
 
@@ -31,6 +30,34 @@ namespace NaughtyAttributes.Editor
 		
 		protected virtual void OnEnable()
 		{
+			/*
+			 * TODO:
+			 * OnEnable is called for all monos and scriptable objects,
+			 * which eats some one time perf after compilation and also takes some memory (although not noticeable)
+			 * any other way to trigger this like via a custom editor/ window with on focus??
+			 *
+			 * Selection.selectionChanged += ????
+			 * Base Mono and SO scripts that handle this??
+			 */
+			
+			this.Prepare();
+		}
+
+		protected virtual void OnDisable()
+		{
+			//cleanup memory
+			ReorderableListPropertyDrawer.Instance.ClearCache();
+
+			_foldoutGroupedSerializedProperty = Enumerable.Empty<IGrouping<string, NaughtyProperty>>();
+			_groupedSerialzedProperty = Enumerable.Empty<IGrouping<string, NaughtyProperty>>();
+			_nonGroupedSerializedProperty = Enumerable.Empty<NaughtyProperty>();
+			_serializedProperties.Clear();
+			
+			m_ScriptProperty = default;
+		}
+
+		public virtual void Prepare()
+		{
 			_nonSerializedFields = ReflectionUtility.GetAllFields(
 				target, f => f.GetCustomAttributes(typeof(ShowNonSerializedFieldAttribute), true).Length > 0);
 
@@ -53,11 +80,6 @@ namespace NaughtyAttributes.Editor
 			_groupedSerialzedProperty = GetGroupedProperties(_serializedProperties);
 
 			_foldoutGroupedSerializedProperty = GetFoldoutProperties(_serializedProperties);
-		}
-
-		protected virtual void OnDisable()
-		{
-			ReorderableListPropertyDrawer.Instance.ClearCache();
 		}
 		
 		public override void OnInspectorGUI()

--- a/Assets/NaughtyAttributes/Scripts/Editor/NaughtyInspector.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/NaughtyInspector.cs
@@ -60,7 +60,6 @@ namespace NaughtyAttributes.Editor
 			ReorderableListPropertyDrawer.Instance.ClearCache();
 		}
 		
-
 		public override void OnInspectorGUI()
 		{
 			if (!_anyNaughtyAttribute)
@@ -77,9 +76,11 @@ namespace NaughtyAttributes.Editor
 			DrawButtons();
 		}
 		
-		protected void GetSerializedProperties(ref List<NaughtyProperty> outSerializedProperties)
+		protected virtual void GetSerializedProperties(ref List<NaughtyProperty> outSerializedProperties)
 		{
 			outSerializedProperties.Clear();
+			outSerializedProperties.TrimExcess();
+			
 			using (var iterator = serializedObject.GetIterator())
 			{
 				if (iterator.NextVisible(true))
@@ -95,7 +96,7 @@ namespace NaughtyAttributes.Editor
 			}
 		}
 
-		protected void DrawSerializedProperties()
+		protected virtual void DrawSerializedProperties()
 		{
 			serializedObject.Update();
 
@@ -108,24 +109,24 @@ namespace NaughtyAttributes.Editor
 			}
 
 			// Draw non-grouped serialized properties
-			foreach (var property in _nonGroupedSerializedProperty)
+			foreach (var naughtyProperty in _nonGroupedSerializedProperty)
 			{
-				NaughtyEditorGUI.PropertyField_Layout(property, includeChildren: true);
+				NaughtyEditorGUI.PropertyField_Layout(naughtyProperty, includeChildren: true);
 			}
 
 			// Draw grouped serialized properties
 			foreach (var group in _groupedSerialzedProperty)
 			{
-				IEnumerable<NaughtyProperty> visibleProperties = group.Where(p => PropertyUtility.IsVisible(p.serializedProperty));
+				IEnumerable<NaughtyProperty> visibleProperties = group.Where(p => PropertyUtility.IsVisible(p.showIfAttribute, p.serializedProperty));
 				if (!visibleProperties.Any())
 				{
 					continue;
 				}
 
 				NaughtyEditorGUI.BeginBoxGroup_Layout(group.Key);
-				foreach (var property in visibleProperties)
+				foreach (var naughtyProperty in visibleProperties)
 				{
-					NaughtyEditorGUI.PropertyField_Layout(property, includeChildren: true);
+					NaughtyEditorGUI.PropertyField_Layout(naughtyProperty, includeChildren: true);
 				}
 
 				NaughtyEditorGUI.EndBoxGroup_Layout();
@@ -134,7 +135,7 @@ namespace NaughtyAttributes.Editor
 			// Draw foldout serialized properties
 			foreach (var group in _foldoutGroupedSerializedProperty)
 			{
-				IEnumerable<NaughtyProperty> visibleProperties = group.Where(p => PropertyUtility.IsVisible(p.serializedProperty));
+				IEnumerable<NaughtyProperty> visibleProperties = group.Where(p => PropertyUtility.IsVisible(p.showIfAttribute, p.serializedProperty));
 				if (!visibleProperties.Any())
 				{
 					continue;
@@ -148,9 +149,9 @@ namespace NaughtyAttributes.Editor
 				_foldouts[group.Key].Value = EditorGUILayout.Foldout(_foldouts[group.Key].Value, group.Key, true);
 				if (_foldouts[group.Key].Value)
 				{
-					foreach (var property in visibleProperties)
+					foreach (var naughtyProperty in visibleProperties)
 					{
-						NaughtyEditorGUI.PropertyField_Layout(property, true);
+						NaughtyEditorGUI.PropertyField_Layout(naughtyProperty, true);
 					}
 				}
 			}
@@ -158,7 +159,7 @@ namespace NaughtyAttributes.Editor
 			serializedObject.ApplyModifiedProperties();
 		}
 
-		protected void DrawNonSerializedFields(bool drawHeader = false)
+		protected virtual void DrawNonSerializedFields(bool drawHeader = false)
 		{
 			if (_nonSerializedFields.Any())
 			{
@@ -177,7 +178,7 @@ namespace NaughtyAttributes.Editor
 			}
 		}
 
-		protected void DrawNativeProperties(bool drawHeader = false)
+		protected virtual void DrawNativeProperties(bool drawHeader = false)
 		{
 			if (_nativeProperties.Any())
 			{
@@ -196,7 +197,7 @@ namespace NaughtyAttributes.Editor
 			}
 		}
 
-		protected void DrawButtons(bool drawHeader = false)
+		protected virtual void DrawButtons(bool drawHeader = false)
 		{
 			if (_methods.Any())
 			{

--- a/Assets/NaughtyAttributes/Scripts/Editor/NaughtyInspector.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/NaughtyInspector.cs
@@ -98,19 +98,9 @@ namespace NaughtyAttributes.Editor
 				{
 					do
 					{
-						NaughtyProperty naughtyProperty = new NaughtyProperty();
-						naughtyProperty.property = serializedObject.FindProperty(iterator.name);
-						
-						naughtyProperty.readOnlyAttribute = PropertyUtility.GetAttribute<ReadOnlyAttribute>(naughtyProperty.property);
-						naughtyProperty.enableIfAttribute = PropertyUtility.GetAttribute<EnableIfAttributeBase>(naughtyProperty.property);
-						
-						naughtyProperty.showIfAttribute = PropertyUtility.GetAttribute<ShowIfAttributeBase>(naughtyProperty.property);
-						naughtyProperty.validatorAttributes = PropertyUtility.GetAttributes<ValidatorAttribute>(naughtyProperty.property);
-
-						naughtyProperty.specialCaseDrawerAttribute =
-							PropertyUtility.GetAttribute<SpecialCaseDrawerAttribute>(naughtyProperty.property);
-						
-						outSerializedProperties.Add(naughtyProperty);
+						outSerializedProperties.Add(
+							PropertyUtility.CreateNaughtyProperty(
+								serializedObject.FindProperty(iterator.name)));
 					}
 					while (iterator.NextVisible(false));
 				}

--- a/Assets/NaughtyAttributes/Scripts/Editor/NaughtyInspector.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/NaughtyInspector.cs
@@ -8,19 +8,6 @@ using UnityEngine;
 
 namespace NaughtyAttributes.Editor
 {
-	public class NaughtyProperty
-	{
-		public SerializedProperty property;
-		public SpecialCaseDrawerAttribute specialCaseDrawerAttribute;
-		public ShowIfAttributeBase showIfAttribute;
-
-		public EnableIfAttributeBase enableIfAttribute;
-		
-		public ReadOnlyAttribute readOnlyAttribute;
-
-		public ValidatorAttribute[] validatorAttributes;
-	}
-	
 	[CanEditMultipleObjects]
 	[CustomEditor(typeof(UnityEngine.Object), true)]
 	public class NaughtyInspector : UnityEditor.Editor
@@ -55,12 +42,13 @@ namespace NaughtyAttributes.Editor
 
 			GetSerializedProperties(ref _serializedProperties);
 			
-			_anyNaughtyAttribute = _serializedProperties.Any(p => PropertyUtility.GetAttribute<INaughtyAttribute>(p.property) != null);
+			_anyNaughtyAttribute = _serializedProperties.Any(p => PropertyUtility.GetAttribute<INaughtyAttribute>(p.serializedProperty) != null);
 
 			_nonGroupedSerializedProperty = GetNonGroupedProperties(_serializedProperties);
-			NaughtyProperty[] mScripts = _serializedProperties.Where(p => p.property.name.Equals("m_Script")).ToArray();
 			
-			m_ScriptProperty = mScripts.Length > 0 ? mScripts[0].property : null;
+			//.First(...) doesnt work for some reason because the m_Script field isnt loaded yet I assume
+			NaughtyProperty[] mScripts = _serializedProperties.Where(p => p.serializedProperty.name.Equals("m_Script")).ToArray();
+			m_ScriptProperty = mScripts.Length > 0 ? mScripts[0].serializedProperty : null;
 			
 			_groupedSerialzedProperty = GetGroupedProperties(_serializedProperties);
 
@@ -128,7 +116,7 @@ namespace NaughtyAttributes.Editor
 			// Draw grouped serialized properties
 			foreach (var group in _groupedSerialzedProperty)
 			{
-				IEnumerable<NaughtyProperty> visibleProperties = group.Where(p => PropertyUtility.IsVisible(p.property));
+				IEnumerable<NaughtyProperty> visibleProperties = group.Where(p => PropertyUtility.IsVisible(p.serializedProperty));
 				if (!visibleProperties.Any())
 				{
 					continue;
@@ -146,7 +134,7 @@ namespace NaughtyAttributes.Editor
 			// Draw foldout serialized properties
 			foreach (var group in _foldoutGroupedSerializedProperty)
 			{
-				IEnumerable<NaughtyProperty> visibleProperties = group.Where(p => PropertyUtility.IsVisible(p.property));
+				IEnumerable<NaughtyProperty> visibleProperties = group.Where(p => PropertyUtility.IsVisible(p.serializedProperty));
 				if (!visibleProperties.Any())
 				{
 					continue;
@@ -229,21 +217,21 @@ namespace NaughtyAttributes.Editor
 
 		private static IEnumerable<NaughtyProperty> GetNonGroupedProperties(IEnumerable<NaughtyProperty> properties)
 		{
-			return properties.Where(p => PropertyUtility.GetAttribute<IGroupAttribute>(p.property) == null && !p.property.name.Equals("m_Script"));
+			return properties.Where(p => PropertyUtility.GetAttribute<IGroupAttribute>(p.serializedProperty) == null && !p.serializedProperty.name.Equals("m_Script"));
 		}
 
 		private static IEnumerable<IGrouping<string, NaughtyProperty>> GetGroupedProperties(IEnumerable<NaughtyProperty> properties)
 		{
 			return properties
-				.Where(p => PropertyUtility.GetAttribute<BoxGroupAttribute>(p.property) != null)
-				.GroupBy(p => PropertyUtility.GetAttribute<BoxGroupAttribute>(p.property).Name);
+				.Where(p => PropertyUtility.GetAttribute<BoxGroupAttribute>(p.serializedProperty) != null)
+				.GroupBy(p => PropertyUtility.GetAttribute<BoxGroupAttribute>(p.serializedProperty).Name);
 		}
 
 		private static IEnumerable<IGrouping<string, NaughtyProperty>> GetFoldoutProperties(IEnumerable<NaughtyProperty> properties)
 		{
 			return properties
-				.Where(p => PropertyUtility.GetAttribute<FoldoutAttribute>(p.property) != null)
-				.GroupBy(p => PropertyUtility.GetAttribute<FoldoutAttribute>(p.property).Name);
+				.Where(p => PropertyUtility.GetAttribute<FoldoutAttribute>(p.serializedProperty) != null)
+				.GroupBy(p => PropertyUtility.GetAttribute<FoldoutAttribute>(p.serializedProperty).Name);
 		}
 
 		private static GUIStyle GetHeaderGUIStyle()

--- a/Assets/NaughtyAttributes/Scripts/Editor/NaughtyProperty.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/NaughtyProperty.cs
@@ -1,0 +1,17 @@
+using UnityEditor;
+
+namespace NaughtyAttributes.Editor
+{
+    public class NaughtyProperty
+    {
+        public SerializedProperty serializedProperty;
+        public SpecialCaseDrawerAttribute specialCaseDrawerAttribute;
+        public ShowIfAttributeBase showIfAttribute;
+
+        public EnableIfAttributeBase enableIfAttribute;
+
+        public ReadOnlyAttribute readOnlyAttribute;
+
+        public ValidatorAttribute[] validatorAttributes;
+    }
+}

--- a/Assets/NaughtyAttributes/Scripts/Editor/NaughtyProperty.cs.meta
+++ b/Assets/NaughtyAttributes/Scripts/Editor/NaughtyProperty.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 12288d0262da08245af3b1fef6421c75
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/AnimatorParamPropertyDrawer.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/AnimatorParamPropertyDrawer.cs
@@ -12,10 +12,16 @@ namespace NaughtyAttributes.Editor
 		private const string InvalidAnimatorControllerWarningMessage = "Target animator controller is null";
 		private const string InvalidTypeWarningMessage = "{0} must be an int or a string";
 
+		private AnimatorController _cachedAnimatorController;
+		
 		protected override float GetPropertyHeight_Internal(SerializedProperty property, GUIContent label)
 		{
 			AnimatorParamAttribute animatorParamAttribute = PropertyUtility.GetAttribute<AnimatorParamAttribute>(property);
-			bool validAnimatorController = GetAnimatorController(property, animatorParamAttribute.AnimatorName) != null;
+
+			if (_cachedAnimatorController == null)
+				_cachedAnimatorController = GetAnimatorController(property, animatorParamAttribute.AnimatorName);
+			
+			bool validAnimatorController = _cachedAnimatorController != null;
 			bool validPropertyType = property.propertyType == SerializedPropertyType.Integer || property.propertyType == SerializedPropertyType.String;
 
 			return (validAnimatorController && validPropertyType)
@@ -29,7 +35,7 @@ namespace NaughtyAttributes.Editor
 
 			AnimatorParamAttribute animatorParamAttribute = PropertyUtility.GetAttribute<AnimatorParamAttribute>(property);
 
-			AnimatorController animatorController = GetAnimatorController(property, animatorParamAttribute.AnimatorName);
+			AnimatorController animatorController = _cachedAnimatorController;
 			if (animatorController == null)
 			{
 				DrawDefaultPropertyAndHelpBox(rect, property, InvalidAnimatorControllerWarningMessage, MessageType.Warning);
@@ -131,39 +137,60 @@ namespace NaughtyAttributes.Editor
 			object target = PropertyUtility.GetTargetObjectWithProperty(property);
 
 			FieldInfo animatorFieldInfo = ReflectionUtility.GetField(target, animatorName);
-			if (animatorFieldInfo != null &&
-				animatorFieldInfo.FieldType == typeof(Animator))
+			if (animatorFieldInfo != null)
 			{
-				Animator animator = animatorFieldInfo.GetValue(target) as Animator;
-				if (animator != null)
+				if (animatorFieldInfo.FieldType == typeof(Animator))
 				{
-					AnimatorController animatorController = animator.runtimeAnimatorController as AnimatorController;
-					return animatorController;
+					Animator animator = animatorFieldInfo.GetValue(target) as Animator;
+					if (animator != null)
+					{
+						AnimatorController animatorController =
+							animator.runtimeAnimatorController as AnimatorController;
+						return animatorController;
+					}
+				}
+				else if (animatorFieldInfo.FieldType == typeof(AnimatorController))
+				{
+					return animatorFieldInfo.GetValue(target) as AnimatorController;
 				}
 			}
 
 			PropertyInfo animatorPropertyInfo = ReflectionUtility.GetProperty(target, animatorName);
-			if (animatorPropertyInfo != null &&
-				animatorPropertyInfo.PropertyType == typeof(Animator))
+			if (animatorPropertyInfo != null)
 			{
-				Animator animator = animatorPropertyInfo.GetValue(target) as Animator;
-				if (animator != null)
+				if (animatorPropertyInfo.PropertyType == typeof(Animator))
 				{
-					AnimatorController animatorController = animator.runtimeAnimatorController as AnimatorController;
-					return animatorController;
+					Animator animator = animatorPropertyInfo.GetValue(target) as Animator;
+					if (animator != null)
+					{
+						AnimatorController animatorController =
+							animator.runtimeAnimatorController as AnimatorController;
+						return animatorController;
+					}
+				}
+				else if (animatorPropertyInfo.PropertyType == typeof(AnimatorController))
+				{
+					return animatorPropertyInfo.GetValue(target) as AnimatorController;
 				}
 			}
 
 			MethodInfo animatorGetterMethodInfo = ReflectionUtility.GetMethod(target, animatorName);
 			if (animatorGetterMethodInfo != null &&
-				animatorGetterMethodInfo.ReturnType == typeof(Animator) &&
-				animatorGetterMethodInfo.GetParameters().Length == 0)
+			    animatorGetterMethodInfo.GetParameters().Length == 0)
 			{
-				Animator animator = animatorGetterMethodInfo.Invoke(target, null) as Animator;
-				if (animator != null)
+				if (animatorGetterMethodInfo.ReturnType == typeof(Animator))
 				{
-					AnimatorController animatorController = animator.runtimeAnimatorController as AnimatorController;
-					return animatorController;
+					Animator animator = animatorGetterMethodInfo.Invoke(target, null) as Animator;
+					if (animator != null)
+					{
+						AnimatorController animatorController =
+							animator.runtimeAnimatorController as AnimatorController;
+						return animatorController;
+					}
+				}
+				else if (animatorGetterMethodInfo.ReturnType == typeof(AnimatorController))
+				{
+					return animatorGetterMethodInfo.Invoke(target, null) as AnimatorController;
 				}
 			}
 

--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/ExpandablePropertyDrawer.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/ExpandablePropertyDrawer.cs
@@ -128,7 +128,7 @@ namespace NaughtyAttributes.Editor
 
 			EditorGUI.EndProperty();
 		}
-
+		
 		private void DrawChildProperties(Rect rect, SerializedProperty property)
 		{
 			ScriptableObject scriptableObject = property.objectReferenceValue as ScriptableObject;
@@ -180,7 +180,9 @@ namespace NaughtyAttributes.Editor
 								height = childHeight
 							};
 
-							NaughtyEditorGUI.PropertyField(childRect, new NaughtyProperty(){property=childProperty}, true);
+							//TODO since the depth can go deeper we cant just use one field. - need better caching and mapping here!
+							//_naughtyProperty ??= PropertyUtility.CreateNaughtyProperty(childProperty);
+							NaughtyEditorGUI.PropertyField(childRect, PropertyUtility.CreateNaughtyProperty(childProperty), true);
 
 							yOffset += childHeight;
 						}

--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/ExpandablePropertyDrawer.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/ExpandablePropertyDrawer.cs
@@ -180,7 +180,7 @@ namespace NaughtyAttributes.Editor
 								height = childHeight
 							};
 
-							NaughtyEditorGUI.PropertyField(childRect, childProperty, true);
+							NaughtyEditorGUI.PropertyField(childRect, new NaughtyProperty(){property=childProperty}, true);
 
 							yOffset += childHeight;
 						}

--- a/Assets/NaughtyAttributes/Scripts/Editor/Utility/NaughtyEditorGUI.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/Utility/NaughtyEditorGUI.cs
@@ -17,63 +17,63 @@ namespace NaughtyAttributes.Editor
 
 		private static GUIStyle _buttonStyle = new GUIStyle(GUI.skin.button) { richText = true };
 
-		private delegate void PropertyFieldFunction(Rect rect, NaughtyProperty property, GUIContent label, bool includeChildren);
+		private delegate void PropertyFieldFunction(Rect rect, NaughtyProperty naughtyProperty, GUIContent label, bool includeChildren);
 
-		public static void PropertyField(Rect rect, NaughtyProperty property, bool includeChildren)
+		public static void PropertyField(Rect rect, NaughtyProperty naughtyProperty, bool includeChildren)
 		{
-			PropertyField_Implementation(rect, property, includeChildren, DrawPropertyField);
+			PropertyField_Implementation(rect, naughtyProperty, includeChildren, DrawPropertyField);
 		}
 
-		public static void PropertyField_Layout(NaughtyProperty property, bool includeChildren)
+		public static void PropertyField_Layout(NaughtyProperty naughtyProperty, bool includeChildren)
 		{
 			Rect dummyRect = new Rect();
-			PropertyField_Implementation(dummyRect, property, includeChildren, DrawPropertyField_Layout);
+			PropertyField_Implementation(dummyRect, naughtyProperty, includeChildren, DrawPropertyField_Layout);
 		}
 
-		private static void DrawPropertyField(Rect rect, NaughtyProperty property, GUIContent label, bool includeChildren)
+		private static void DrawPropertyField(Rect rect, NaughtyProperty naughtyProperty, GUIContent label, bool includeChildren)
 		{
-			EditorGUI.PropertyField(rect, property.property, label, includeChildren);
+			EditorGUI.PropertyField(rect, naughtyProperty.serializedProperty, label, includeChildren);
 		}
 
-		private static void DrawPropertyField_Layout(Rect rect, NaughtyProperty property, GUIContent label, bool includeChildren)
+		private static void DrawPropertyField_Layout(Rect rect, NaughtyProperty naughtyProperty, GUIContent label, bool includeChildren)
 		{
-			EditorGUILayout.PropertyField(property.property, label, includeChildren);
+			EditorGUILayout.PropertyField(naughtyProperty.serializedProperty, label, includeChildren);
 		}
 
-		private static void PropertyField_Implementation(Rect rect, NaughtyProperty property, bool includeChildren, PropertyFieldFunction propertyFieldFunction)
+		private static void PropertyField_Implementation(Rect rect, NaughtyProperty naughtyProperty, bool includeChildren, PropertyFieldFunction propertyFieldFunction)
 		{
-			if (property.specialCaseDrawerAttribute != null)
+			if (naughtyProperty.specialCaseDrawerAttribute != null)
 			{
-				property.specialCaseDrawerAttribute.GetDrawer().OnGUI(rect, property.property);
+				naughtyProperty.specialCaseDrawerAttribute.GetDrawer().OnGUI(rect, naughtyProperty.serializedProperty);
 			}
 			else
 			{
 				// Check if visible
-				bool visible = PropertyUtility.IsVisible(property.showIfAttribute, property.property);
+				bool visible = PropertyUtility.IsVisible(naughtyProperty.showIfAttribute, naughtyProperty.serializedProperty);
 				if (!visible)
 				{
 					return;
 				}
 				
 				// Validate
-				foreach (var validatorAttribute in property.validatorAttributes)
+				foreach (var validatorAttribute in naughtyProperty.validatorAttributes)
 				{
-					validatorAttribute.GetValidator().ValidateProperty(property.property);
+					validatorAttribute.GetValidator().ValidateProperty(naughtyProperty.serializedProperty);
 				}
 				
 				// Check if enabled and draw
 				EditorGUI.BeginChangeCheck();
-				bool enabled = PropertyUtility.IsEnabled(property.readOnlyAttribute, property.enableIfAttribute, property.property);
+				bool enabled = PropertyUtility.IsEnabled(naughtyProperty.readOnlyAttribute, naughtyProperty.enableIfAttribute, naughtyProperty.serializedProperty);
 				
 				using (new EditorGUI.DisabledScope(disabled: !enabled))
 				{
-					propertyFieldFunction.Invoke(rect, property, PropertyUtility.GetLabel(property.property), includeChildren);
+					propertyFieldFunction.Invoke(rect, naughtyProperty, PropertyUtility.GetLabel(naughtyProperty.serializedProperty), includeChildren);
 				}
 				
 				// Call OnValueChanged callbacks
 				if (EditorGUI.EndChangeCheck())
 				{
-					PropertyUtility.CallOnValueChangedCallbacks(property.property);
+					PropertyUtility.CallOnValueChangedCallbacks(naughtyProperty.serializedProperty);
 				}
 			}
 		}

--- a/Assets/NaughtyAttributes/Scripts/Editor/Utility/PropertyUtility.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/Utility/PropertyUtility.cs
@@ -26,19 +26,19 @@ namespace NaughtyAttributes.Editor
 			return (T[])fieldInfo.GetCustomAttributes(typeof(T), true);
 		}
 
-		public static NaughtyProperty CreateNaughtyProperty(SerializedProperty property)
+		public static NaughtyProperty CreateNaughtyProperty(SerializedProperty serializedProperty)
 		{
 			NaughtyProperty naughtyProperty = new NaughtyProperty();
-			naughtyProperty.property = property;
+			naughtyProperty.serializedProperty = serializedProperty;
 
-			naughtyProperty.readOnlyAttribute = PropertyUtility.GetAttribute<ReadOnlyAttribute>(naughtyProperty.property);
-			naughtyProperty.enableIfAttribute = PropertyUtility.GetAttribute<EnableIfAttributeBase>(naughtyProperty.property);
+			naughtyProperty.readOnlyAttribute = PropertyUtility.GetAttribute<ReadOnlyAttribute>(naughtyProperty.serializedProperty);
+			naughtyProperty.enableIfAttribute = PropertyUtility.GetAttribute<EnableIfAttributeBase>(naughtyProperty.serializedProperty);
 						
-			naughtyProperty.showIfAttribute = PropertyUtility.GetAttribute<ShowIfAttributeBase>(naughtyProperty.property);
-			naughtyProperty.validatorAttributes = PropertyUtility.GetAttributes<ValidatorAttribute>(naughtyProperty.property);
+			naughtyProperty.showIfAttribute = PropertyUtility.GetAttribute<ShowIfAttributeBase>(naughtyProperty.serializedProperty);
+			naughtyProperty.validatorAttributes = PropertyUtility.GetAttributes<ValidatorAttribute>(naughtyProperty.serializedProperty);
 
 			naughtyProperty.specialCaseDrawerAttribute =
-				PropertyUtility.GetAttribute<SpecialCaseDrawerAttribute>(naughtyProperty.property);
+				PropertyUtility.GetAttribute<SpecialCaseDrawerAttribute>(naughtyProperty.serializedProperty);
 			
 			return naughtyProperty;
 		}

--- a/Assets/NaughtyAttributes/Scripts/Editor/Utility/PropertyUtility.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/Utility/PropertyUtility.cs
@@ -26,6 +26,23 @@ namespace NaughtyAttributes.Editor
 			return (T[])fieldInfo.GetCustomAttributes(typeof(T), true);
 		}
 
+		public static NaughtyProperty CreateNaughtyProperty(SerializedProperty property)
+		{
+			NaughtyProperty naughtyProperty = new NaughtyProperty();
+			naughtyProperty.property = property;
+
+			naughtyProperty.readOnlyAttribute = PropertyUtility.GetAttribute<ReadOnlyAttribute>(naughtyProperty.property);
+			naughtyProperty.enableIfAttribute = PropertyUtility.GetAttribute<EnableIfAttributeBase>(naughtyProperty.property);
+						
+			naughtyProperty.showIfAttribute = PropertyUtility.GetAttribute<ShowIfAttributeBase>(naughtyProperty.property);
+			naughtyProperty.validatorAttributes = PropertyUtility.GetAttributes<ValidatorAttribute>(naughtyProperty.property);
+
+			naughtyProperty.specialCaseDrawerAttribute =
+				PropertyUtility.GetAttribute<SpecialCaseDrawerAttribute>(naughtyProperty.property);
+			
+			return naughtyProperty;
+		}
+
 		public static GUIContent GetLabel(SerializedProperty property)
 		{
 			LabelAttribute labelAttribute = GetAttribute<LabelAttribute>(property);

--- a/Assets/NaughtyAttributes/Scripts/Editor/Utility/PropertyUtility.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/Utility/PropertyUtility.cs
@@ -71,17 +71,23 @@ namespace NaughtyAttributes.Editor
 		public static bool IsEnabled(SerializedProperty property)
 		{
 			ReadOnlyAttribute readOnlyAttribute = GetAttribute<ReadOnlyAttribute>(property);
+			EnableIfAttributeBase enableIfAttribute = GetAttribute<EnableIfAttributeBase>(property);
+
+			return IsEnabled(readOnlyAttribute, enableIfAttribute, property);
+		}
+
+		public static bool IsEnabled(ReadOnlyAttribute readOnlyAttribute, EnableIfAttributeBase enableIfAttribute, SerializedProperty property)
+		{
 			if (readOnlyAttribute != null)
 			{
 				return false;
 			}
-
-			EnableIfAttributeBase enableIfAttribute = GetAttribute<EnableIfAttributeBase>(property);
+			
 			if (enableIfAttribute == null)
 			{
 				return true;
 			}
-
+			
 			object target = GetTargetObjectWithProperty(property);
 
 			// deal with enum conditions
@@ -118,10 +124,16 @@ namespace NaughtyAttributes.Editor
 				return false;
 			}
 		}
-
+		
 		public static bool IsVisible(SerializedProperty property)
 		{
 			ShowIfAttributeBase showIfAttribute = GetAttribute<ShowIfAttributeBase>(property);
+
+			return IsVisible(showIfAttribute, property);
+		}
+
+		public static bool IsVisible(ShowIfAttributeBase showIfAttribute, SerializedProperty property)
+		{
 			if (showIfAttribute == null)
 			{
 				return true;
@@ -142,7 +154,8 @@ namespace NaughtyAttributes.Editor
 					return matched != showIfAttribute.Inverted;
 				}
 
-				string message = showIfAttribute.GetType().Name + " needs a valid enum field, property or method name to work";
+				string message = showIfAttribute.GetType().Name +
+				                 " needs a valid enum field, property or method name to work";
 				Debug.LogWarning(message, property.serializedObject.targetObject);
 
 				return false;
@@ -152,12 +165,14 @@ namespace NaughtyAttributes.Editor
 			List<bool> conditionValues = GetConditionValues(target, showIfAttribute.Conditions);
 			if (conditionValues.Count > 0)
 			{
-				bool enabled = GetConditionsFlag(conditionValues, showIfAttribute.ConditionOperator, showIfAttribute.Inverted);
+				bool enabled = GetConditionsFlag(conditionValues, showIfAttribute.ConditionOperator,
+					showIfAttribute.Inverted);
 				return enabled;
 			}
 			else
 			{
-				string message = showIfAttribute.GetType().Name + " needs a valid boolean condition field, property or method name to work";
+				string message = showIfAttribute.GetType().Name +
+				                 " needs a valid boolean condition field, property or method name to work";
 				Debug.LogWarning(message, property.serializedObject.targetObject);
 
 				return false;

--- a/Assets/NaughtyAttributes/Scripts/Test/AnimatorParamTest.cs
+++ b/Assets/NaughtyAttributes/Scripts/Test/AnimatorParamTest.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using UnityEditor.Animations;
+using UnityEngine;
 
 namespace NaughtyAttributes.Test
 {
@@ -6,20 +7,31 @@ namespace NaughtyAttributes.Test
 	{
 		public Animator animator0;
 
-		[AnimatorParam("animator0")]
-		public int hash0;
+		public AnimatorController animatorController0;
 
 		[AnimatorParam("animator0")]
+		public int hash0;
+		[AnimatorParam("animator0")]
 		public string name0;
+		
+		[AnimatorParam("animatorController0")]
+		public int hashController0;
+
+		[AnimatorParam("animatorController0")]
+		public string nameController0;
 
 		public AnimatorParamNest1 nest1;
 
-		[Button("Log 'hash0' and 'name0'")]
+		[Button("Log 'hash0', 'hashController0' and 'name0', 'nameController0'")]
 		private void TestLog()
 		{
 			Debug.Log($"hash0 = {hash0}");
 			Debug.Log($"name0 = {name0}");
 			Debug.Log($"Animator.StringToHash(name0) = {Animator.StringToHash(name0)}");
+			
+			Debug.Log($"hashController0 = {hashController0}");
+			Debug.Log($"nameController0 = {nameController0}");
+			Debug.Log($"Animator.StringToHash(nameController0) = {Animator.StringToHash(nameController0)}");
 		}
 	}
 
@@ -27,14 +39,24 @@ namespace NaughtyAttributes.Test
 	public class AnimatorParamNest1
 	{
 		public Animator animator1;
-		private Animator Animator1 => animator1;
+		public AnimatorController animatorController1;
 
+		private Animator Animator1 => animator1;
+		
+		private AnimatorController AnimatorController1 => animatorController1;
+		
 		[AnimatorParam("Animator1", AnimatorControllerParameterType.Bool)]
 		public int hash1;
 
 		[AnimatorParam("Animator1", AnimatorControllerParameterType.Float)]
 		public string name1;
+		
+		[AnimatorParam("AnimatorController1", AnimatorControllerParameterType.Bool)]
+		public int hashController1;
 
+		[AnimatorParam("AnimatorController1", AnimatorControllerParameterType.Float)]
+		public string nameController1;
+		
 		public AnimatorParamNest2 nest2;
 	}
 
@@ -42,12 +64,22 @@ namespace NaughtyAttributes.Test
 	public class AnimatorParamNest2
 	{
 		public Animator animator2;
+		public AnimatorController animatorController2;
+
 		private Animator GetAnimator2() => animator2;
+		
+		private AnimatorController GetAnimatorController2() => animatorController2;
 
 		[AnimatorParam("GetAnimator2", AnimatorControllerParameterType.Int)]
 		public int hash1;
 
 		[AnimatorParam("GetAnimator2", AnimatorControllerParameterType.Trigger)]
 		public string name1;
+		
+		[AnimatorParam("GetAnimatorController2", AnimatorControllerParameterType.Int)]
+		public int hashController2;
+
+		[AnimatorParam("GetAnimatorController2", AnimatorControllerParameterType.Trigger)]
+		public string nameController2;
 	}
 }

--- a/Assets/NaughtyAttributes/Scripts/Test/CurveRangeTest.cs
+++ b/Assets/NaughtyAttributes/Scripts/Test/CurveRangeTest.cs
@@ -1,32 +1,30 @@
 ﻿using UnityEngine;
 using NaughtyAttributes;
 
-public class CurveRangeTest : MonoBehaviour
+namespace NaughtyAttributes.Test
 {
-	[CurveRange(-1, -1, 1, 1, EColor.Red)]
-	public AnimationCurve curve;
-
-	[CurveRange(EColor.Orange)]
-	public AnimationCurve curve1;
-
-	[CurveRange(0, 0, 10, 10)]
-	public AnimationCurve curve2;
-
-	public CurveRangeNest1 nest1;
-
-	[System.Serializable]
-	public class CurveRangeNest1
+	public class CurveRangeTest : MonoBehaviour
 	{
-		[CurveRange(0, 0, 1, 1, EColor.Green)]
-		public AnimationCurve curve;
+		[CurveRange(-1, -1, 1, 1, EColor.Red)] public AnimationCurve curve;
 
-		public CurveRangeNest2 nest2;
-	}
+		[CurveRange(EColor.Orange)] public AnimationCurve curve1;
 
-	[System.Serializable]
-	public class CurveRangeNest2
-	{
-		[CurveRange(0, 0, 5, 5, EColor.Blue)]
-		public AnimationCurve curve;
+		[CurveRange(0, 0, 10, 10)] public AnimationCurve curve2;
+
+		public CurveRangeNest1 nest1;
+
+		[System.Serializable]
+		public class CurveRangeNest1
+		{
+			[CurveRange(0, 0, 1, 1, EColor.Green)] public AnimationCurve curve;
+
+			public CurveRangeNest2 nest2;
+		}
+
+		[System.Serializable]
+		public class CurveRangeNest2
+		{
+			[CurveRange(0, 0, 5, 5, EColor.Blue)] public AnimationCurve curve;
+		}
 	}
 }

--- a/Assets/NaughtyAttributes/Scripts/Test/HugeMixPerformanceTest.cs
+++ b/Assets/NaughtyAttributes/Scripts/Test/HugeMixPerformanceTest.cs
@@ -1,0 +1,304 @@
+using System.Collections;
+using UnityEngine;
+
+namespace NaughtyAttributes.Test
+{
+    public class HugeMixPerformanceTest : MonoBehaviour
+    {
+        #region AnimatorParamTest
+        
+        public Animator animator0;
+
+        [AnimatorParam("animator0")]
+        public int hash0;
+
+        [AnimatorParam("animator0")]
+        public string name0;
+
+        public AnimatorParamNest1 animatorParamNest1;
+
+        [Button("Log 'hash0' and 'name0'")]
+        private void TestLog()
+        {
+            Debug.Log($"hash0 = {hash0}");
+            Debug.Log($"name0 = {name0}");
+            Debug.Log($"Animator.StringToHash(name0) = {Animator.StringToHash(name0)}");
+        }
+        
+        #endregion
+
+        #region BoxGroupTest
+        
+        [BoxGroup("Integers")]
+        public int int0;
+        [BoxGroup("Integers")]
+        public int int1;
+
+        [BoxGroup("Floats")]
+        public float float0;
+        [BoxGroup("Floats")]
+        public float float1;
+
+        [BoxGroup("Sliders")]
+        [MinMaxSlider(0, 1)]
+        public Vector2 slider0;
+        [BoxGroup("Sliders")]
+        [MinMaxSlider(0, 1)]
+        public Vector2 slider1;
+
+        public string str0;
+        public string str1;
+
+        [BoxGroup]
+        public Transform trans0;
+        [BoxGroup]
+        public Transform trans1;
+        
+        #endregion
+
+        #region ButtonTest
+        
+        public int myInt;
+
+        [Button(enabledMode: EButtonEnableMode.Always)]
+        private void IncrementMyInt()
+        {
+            myInt++;
+        }
+
+        [Button("Decrement My Int", EButtonEnableMode.Editor)]
+        private void DecrementMyInt()
+        {
+            myInt--;
+        }
+
+        [Button(enabledMode: EButtonEnableMode.Playmode)]
+        private void LogMyInt(string prefix = "MyInt = ")
+        {
+            Debug.Log(prefix + myInt);
+        }
+
+        [Button("StartCoroutine")]
+        private IEnumerator IncrementMyIntCoroutine()
+        {
+            int seconds = 5;
+            for (int i = 0; i < seconds; i++)
+            {
+                myInt++;
+                yield return new WaitForSeconds(1.0f);
+            }
+        }
+        
+        #endregion
+
+        #region CurveRangeTest
+        
+        [CurveRange(-1, -1, 1, 1, EColor.Red)] public AnimationCurve curve;
+
+        [CurveRange(EColor.Orange)] public AnimationCurve curve1;
+
+        [CurveRange(0, 0, 10, 10)] public AnimationCurve curve2;
+
+        public CurveRangeNest1 curveRangeNest1;
+
+        [System.Serializable]
+        public class CurveRangeNest1
+        {
+            [CurveRange(0, 0, 1, 1, EColor.Green)] public AnimationCurve curve;
+
+            public CurveRangeNest2 curveRangeNest2;
+        }
+
+        [System.Serializable]
+        public class CurveRangeNest2
+        {
+            [CurveRange(0, 0, 5, 5, EColor.Blue)] public AnimationCurve curve;
+        }
+        
+        #endregion
+
+        #region DisableIfTest
+        
+        public bool disableIf1;
+        public bool disableIf2;
+        public DisableIfEnum disableIfEnum1;
+        [EnumFlags] public DisableIfEnumFlag disableIfEnum2;
+        
+        [DisableIf(EConditionOperator.And, "disableIf1", "disableIf2")]
+        [ReorderableList]
+        public int[] disableIfAll;
+        
+        [DisableIf(EConditionOperator.Or, "disableIf1", "disableIf2")]
+        [ReorderableList]
+        public int[] disableIfAny;
+        
+        [DisableIf("disableIfEnum1", DisableIfEnum.Case0)]
+        [ReorderableList]
+        public int[] disableIfEnum;
+        
+        [DisableIf("disableIfEnum2", DisableIfEnumFlag.Flag0)]
+        [ReorderableList]
+        public int[] disableIfEnumFlag;
+        
+        [DisableIf("disableIfEnum2", DisableIfEnumFlag.Flag0 | DisableIfEnumFlag.Flag1)]
+        [ReorderableList]
+        public int[] disableIfEnumFlagMulti;
+        
+        public DisableIfNest1 disableIfNest1;
+        
+        #endregion
+
+        #region DropDownTest
+
+        [Dropdown("dropDownIntValues")]
+        public int dropDownIntValue;
+
+#pragma warning disable 414
+        private int[] dropDownIntValues = new int[] { 1, 2, 3 };
+#pragma warning restore 414
+
+        public DropdownNest1 dropdownNest1;
+
+        #endregion
+
+        #region EnableIfTest
+
+        public bool enable1;
+        public bool enable2;
+        public EnableIfEnum enableIfEnum1;
+        [EnumFlags] public EnableIfEnumFlag enableIfEnum2;
+
+        [EnableIf(EConditionOperator.And, "enable1", "enable2")]
+        [ReorderableList]
+        public int[] enableIfAll;
+
+        [EnableIf(EConditionOperator.Or, "enable1", "enable2")]
+        [ReorderableList]
+        public int[] enableIfAny;
+
+        [EnableIf("enableIfEnum1", EnableIfEnum.Case0)]
+        [ReorderableList]
+        public int[] enableIfEnum;
+
+        [EnableIf("enableIfEnum2", EnableIfEnumFlag.Flag0)]
+        [ReorderableList]
+        public int[] enableIfEnumFlag;
+
+        [EnableIf("enableIfEnum2", EnableIfEnumFlag.Flag0 | EnableIfEnumFlag.Flag1)]
+        [ReorderableList]
+        public int[] enableIfEnumFlagMulti;
+
+        public EnableIfNest1 enableIfNest1;
+
+        #endregion
+
+        #region EnumFlagsTest
+
+        [EnumFlags]
+        public TestEnum enumFlagsTest0;
+
+        public EnumFlagsNest1 enumFlagsNest1;
+
+        #endregion
+
+        #region ExpandableTest
+
+        [Expandable]
+        public ScriptableObject obj0;
+
+        public ExpandableScriptableObjectNest1 expandableScriptableObjectNest1;
+
+        #endregion
+
+        #region FoldoutTest
+
+        [Foldout("Integers")]
+        public int foldoutTestInt0;
+        [Foldout("Integers")]
+        public int foldoutTestInt1;
+
+        [Foldout("Floats")]
+        public float foldoutTestFloat0;
+        [Foldout("Floats")]
+        public float foldoutTestFloat1;
+
+        [Foldout("Sliders")]
+        [MinMaxSlider(0, 1)]
+        public Vector2 foldoutTestSlider0;
+        [Foldout("Sliders")]
+        [MinMaxSlider(0, 1)]
+        public Vector2 foldoutTestSlider1;
+
+        public string foldoutTestStr0;
+        public string foldoutTestStr1;
+
+        [Foldout("Transforms")]
+        public Transform foldoutTestTrans0;
+        [Foldout("Transforms")]
+        public Transform foldoutTestTrans1;
+
+        #endregion
+
+        #region HideIfTest
+
+        public bool hide1;
+        public bool hide2;
+        public HideIfEnum hideIfEnum1;
+        [EnumFlags] public HideIfEnumFlag hideIfEnum2;
+
+        [HideIf(EConditionOperator.And, "hide1", "hide2")]
+        [ReorderableList]
+        public int[] hideIfAll;
+
+        [HideIf(EConditionOperator.Or, "hide1", "hide2")]
+        [ReorderableList]
+        public int[] hideIfAny;
+
+        [HideIf("hideIfEnum1", HideIfEnum.Case0)]
+        [ReorderableList]
+        public int[] hideIfEnum;
+
+        [HideIf("hideIfEnum2", HideIfEnumFlag.Flag0)]
+        [ReorderableList]
+        public int[] hideIfEnumFlag;
+
+        [HideIf("hideIfEnum2", HideIfEnumFlag.Flag0 | HideIfEnumFlag.Flag1)]
+        [ReorderableList]
+        public int[] hideIfEnumFlagMulti;
+
+        public HideIfNest1 hideIfNest1;
+
+        #endregion
+        
+        #region ShowIfTest
+        
+        public bool showIf1;
+        public bool showIf2;
+        public ShowIfEnum showIfEnum1;
+        [EnumFlags] public ShowIfEnumFlag showIfEnum2;
+        
+        [ShowIf(EConditionOperator.And, "showIf1", "showIf2")]
+        [ReorderableList]
+        public int[] showIfAll;
+        
+        [ShowIf(EConditionOperator.Or, "showIf1", "showIf2")]
+        [ReorderableList]
+        public int[] showIfAny;
+        
+        [ShowIf("showIfEnum1", ShowIfEnum.Case0)]
+        [ReorderableList]
+        public int[] showIfEnum;
+        
+        [ShowIf("showIfEnum2", ShowIfEnumFlag.Flag0)]
+        [ReorderableList]
+        public int[] showIfEnumFlag;
+        
+        [ShowIf("showIfEnum2", ShowIfEnumFlag.Flag0 | ShowIfEnumFlag.Flag1)]
+        [ReorderableList]
+        public int[] showIfEnumFlagMulti;
+        
+        public ShowIfNest1 showIfNest1;
+        
+        #endregion
+    }
+}

--- a/Assets/NaughtyAttributes/Scripts/Test/HugeMixPerformanceTest.cs.meta
+++ b/Assets/NaughtyAttributes/Scripts/Test/HugeMixPerformanceTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9d0844cc6e62fe54393612902562c4e2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/NaughtyAttributes/Scripts/Test/_NaughtyScriptableObject.cs
+++ b/Assets/NaughtyAttributes/Scripts/Test/_NaughtyScriptableObject.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using UnityEditor.Animations;
 using UnityEngine;
 
 namespace NaughtyAttributes.Test
@@ -8,5 +9,22 @@ namespace NaughtyAttributes.Test
 	{
 		[Expandable]
 		public List<_TestScriptableObject> list;
+
+		public AnimatorController animatorController0;
+		
+		[AnimatorParam(nameof(animatorController0))]
+		public int hashController0;
+
+		[AnimatorParam(nameof(animatorController0))]
+		public string nameController0;
+		
+		
+		[Button("Log 'hashController0' and 'nameController0'")]
+		private void TestLog()
+		{
+			Debug.Log($"hashController0 = {hashController0}");
+			Debug.Log($"nameController0 = {nameController0}");
+			Debug.Log($"Animator.StringToHash(nameController0) = {Animator.StringToHash(nameController0)}");
+		}
 	}
 }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -3,6 +3,7 @@
     "com.unity.2d.sprite": "1.0.0",
     "com.unity.2d.tilemap": "1.0.0",
     "com.unity.collab-proxy": "1.3.9",
+    "com.unity.ide.rider": "3.0.7",
     "com.unity.ide.visualstudio": "2.0.7",
     "com.unity.test-framework": "1.1.24",
     "com.unity.textmeshpro": "3.0.4",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -26,6 +26,15 @@
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
+    "com.unity.ide.rider": {
+      "version": "3.0.7",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.ext.nunit": "1.0.6"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.ide.visualstudio": {
       "version": "2.0.7",
       "depth": 0,


### PR DESCRIPTION
To use the selectable Animator Controller params feature in Scriptable Objects aswell, I modified the anim params attribute property drawer to detect animator controllers aswell. 
Also added caching to avoid repetetive reflection calls to get the anim controller.

This branch is based on the lag fix #133 but the anim property drawer code can be used independently if wanted.