### PR TITLE
Add: Multi-selection Button

### DIFF
--- a/Assets/NaughtyAttributes/Scripts/Editor/Utility/NaughtyEditorGUI.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/Utility/NaughtyEditorGUI.cs
@@ -162,29 +162,9 @@ namespace NaughtyAttributes.Editor
 
 				if (GUILayout.Button(buttonText, _buttonStyle))
 				{
-					object[] defaultParams = methodInfo.GetParameters().Select(p => p.DefaultValue).ToArray();
-					IEnumerator methodResult = methodInfo.Invoke(target, defaultParams) as IEnumerator;
-
-					if (!Application.isPlaying)
-					{
-						// Set target object and scene dirty to serialize changes to disk
-						EditorUtility.SetDirty(target);
-
-						PrefabStage stage = PrefabStageUtility.GetCurrentPrefabStage();
-						if (stage != null)
-						{
-							// Prefab mode
-							EditorSceneManager.MarkSceneDirty(stage.scene);
-						}
-						else
-						{
-							// Normal scene
-							EditorSceneManager.MarkSceneDirty(EditorSceneManager.GetActiveScene());
-						}
-					}
-					else if (methodResult != null && target is MonoBehaviour behaviour)
-					{
-						behaviour.StartCoroutine(methodResult);
+					// Let's call the button method for all the selected object in hiearchy
+					foreach(var curr in Selection.objects){
+						OnNaughtyButtonPressed(target, methodInfo);
 					}
 				}
 
@@ -194,6 +174,33 @@ namespace NaughtyAttributes.Editor
 			{
 				string warning = typeof(ButtonAttribute).Name + " works only on methods with no parameters";
 				HelpBox_Layout(warning, MessageType.Warning, context: target, logToConsole: true);
+			}
+		}
+
+		private static void OnNaughtyButtonPressed(UnityEngine.Object target, MethodInfo methodInfo){
+			object[] defaultParams = methodInfo.GetParameters().Select(p => p.DefaultValue).ToArray();
+			IEnumerator methodResult = methodInfo.Invoke(target, defaultParams) as IEnumerator;
+
+			if (!Application.isPlaying)
+			{
+				// Set target object and scene dirty to serialize changes to disk
+				EditorUtility.SetDirty(target);
+
+				PrefabStage stage = PrefabStageUtility.GetCurrentPrefabStage();
+				if (stage != null)
+				{
+					// Prefab mode
+					EditorSceneManager.MarkSceneDirty(stage.scene);
+				}
+				else
+				{
+					// Normal scene
+					EditorSceneManager.MarkSceneDirty(EditorSceneManager.GetActiveScene());
+				}
+			}
+			else if (methodResult != null && target is MonoBehaviour behaviour)
+			{
+				behaviour.StartCoroutine(methodResult);
 			}
 		}
 


### PR DESCRIPTION
Use case:
Multiple objects are selected in the hiearchy.
They share a script that has a [Button] attribute on a method
With this change, the method will be called on all seleted objects, as opposed to only being called on the focused selected object in the inspector.