### PR TITLE
Added an optional format string for `[Dropdown]`

### DIFF
--- a/Assets/NaughtyAttributes/Scripts/Core/DrawerAttributes/DropdownAttribute.cs
+++ b/Assets/NaughtyAttributes/Scripts/Core/DrawerAttributes/DropdownAttribute.cs
@@ -9,14 +9,12 @@ namespace NaughtyAttributes
     {
         public string ValuesName { get; private set; }
 
-        public string DisplayPrefix { get; set; }
-        public string DisplaySuffix { get; set; }
+        public string DisplayFormat { get; set; }
 
-        public DropdownAttribute(string valuesName, string displayPrefix = "", string displaySuffix = "")
+        public DropdownAttribute(string valuesName, string displayFormat = "")
         {
             ValuesName = valuesName;
-            DisplayPrefix = displayPrefix;
-            DisplaySuffix = displaySuffix;
+            DisplayFormat = displayFormat;
         }
     }
 

--- a/Assets/NaughtyAttributes/Scripts/Core/DrawerAttributes/DropdownAttribute.cs
+++ b/Assets/NaughtyAttributes/Scripts/Core/DrawerAttributes/DropdownAttribute.cs
@@ -9,9 +9,14 @@ namespace NaughtyAttributes
     {
         public string ValuesName { get; private set; }
 
-        public DropdownAttribute(string valuesName)
+        public string DisplayPrefix { get; set; }
+        public string DisplaySuffix { get; set; }
+
+        public DropdownAttribute(string valuesName, string displayPrefix = "", string displaySuffix = "")
         {
             ValuesName = valuesName;
+            DisplayPrefix = displayPrefix;
+            DisplaySuffix = displaySuffix;
         }
     }
 

--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/DropdownPropertyDrawer.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/DropdownPropertyDrawer.cs
@@ -32,6 +32,11 @@ namespace NaughtyAttributes.Editor
 
             object valuesObject = GetValues(property, dropdownAttribute.ValuesName);
             FieldInfo dropdownField = ReflectionUtility.GetField(target, property.name);
+            
+            string prefix = dropdownAttribute.DisplayPrefix;
+            string suffix = dropdownAttribute.DisplaySuffix;
+
+            Func<object, string> generateDisplayValue = v => string.Format("{0}{1}{2}", prefix, v, suffix);
 
             if (AreValuesValid(valuesObject, dropdownField))
             {
@@ -49,7 +54,9 @@ namespace NaughtyAttributes.Editor
                     {
                         object value = valuesList[i];
                         values[i] = value;
-                        displayOptions[i] = value == null ? "<null>" : value.ToString();
+                        displayOptions[i] = value == null 
+                                                ? "<null>" 
+                                                : generateDisplayValue(value);
                     }
 
                     // Selected value index
@@ -98,7 +105,7 @@ namespace NaughtyAttributes.Editor
                             }
                             else
                             {
-                                displayOptions.Add(current.Key);
+                                displayOptions.Add(generateDisplayValue(current.Key));
                             }
                         }
                     }

--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/DropdownPropertyDrawer.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/DropdownPropertyDrawer.cs
@@ -32,11 +32,13 @@ namespace NaughtyAttributes.Editor
 
             object valuesObject = GetValues(property, dropdownAttribute.ValuesName);
             FieldInfo dropdownField = ReflectionUtility.GetField(target, property.name);
-            
-            string prefix = dropdownAttribute.DisplayPrefix;
-            string suffix = dropdownAttribute.DisplaySuffix;
 
-            Func<object, string> generateDisplayValue = v => string.Format("{0}{1}{2}", prefix, v, suffix);
+            Func<object, string> generateDisplayValue = v => v.ToString();
+
+            if (!string.IsNullOrWhiteSpace(dropdownAttribute.DisplayFormat))
+            {
+               generateDisplayValue =  v => string.Format(dropdownAttribute.DisplayFormat, v);
+            }
 
             if (AreValuesValid(valuesObject, dropdownField))
             {

--- a/Assets/NaughtyAttributes/Scripts/Test/DropdownTest.cs
+++ b/Assets/NaughtyAttributes/Scripts/Test/DropdownTest.cs
@@ -8,17 +8,24 @@ namespace NaughtyAttributes.Test
         [Dropdown("intValues")]
         public int intValue;
         
-        [Dropdown("intValues", DisplayPrefix = "Number: ")]
+        [Dropdown("intValues", "Number: {0}")]
         public int prefixedIntValue;
 
-        [Dropdown("intValues", DisplaySuffix = " Megabyte(s)")]
+        [Dropdown("intValues", "{0} Megabyte(s)")]
         public int suffixedIntValue;
 
-        [Dropdown("intValues", "Show "," Widgets")]
+        [Dropdown("intValues", "Show {0} Widgets")]
         public int surroundedIntValue;
+        
+        [Dropdown("floatValues", "Value: {0}")]
+        public float floatValue;
+        
+        [Dropdown("floatValues", "{0:0.#%}")]
+        public float formattedFloatValue;
 
 #pragma warning disable 414
         private int[] intValues = new int[] { 1, 2, 3 };
+        private float[] floatValues = new float[] { 0.1234f, 0.5648f, 1.0f };
 #pragma warning restore 414
 
         public DropdownNest1 nest1;
@@ -30,13 +37,13 @@ namespace NaughtyAttributes.Test
         [Dropdown("StringValues")]
         public string stringValue;
         
-        [Dropdown("StringValues", DisplayPrefix = "Letter: ")]
+        [Dropdown("StringValues", "Letter: {0}")]
         public string prefixedStringValue;
 
-        [Dropdown("StringValues", DisplaySuffix = " Grade")]
+        [Dropdown("StringValues", "{0} Grade")]
         public string suffixedStringValue;
 
-        [Dropdown("StringValues", "Hello ", " World")]
+        [Dropdown("StringValues", "Hello {0} World")]
         public string surroundedStringValue;
 
         private List<string> StringValues { get { return new List<string>() { "A", "B", "C" }; } }
@@ -50,13 +57,13 @@ namespace NaughtyAttributes.Test
         [Dropdown("GetVectorValues")]
         public Vector3 vectorValue;
         
-        [Dropdown("GetVectorValues", DisplayPrefix = "Go ")]
+        [Dropdown("GetVectorValues", "Go {0}")]
         public Vector3 prefixedVectorValue;
 
-        [Dropdown("GetVectorValues", DisplaySuffix = " is the way!")]
+        [Dropdown("GetVectorValues", "{0} is the way!")]
         public Vector3 suffixedVectorValue;
 
-        [Dropdown("GetVectorValues", "Go: ", ", now!")]
+        [Dropdown("GetVectorValues", "Go: {0} now!")]
         public Vector3 surroundedVectorValue;
 
         private DropdownList<Vector3> GetVectorValues()

--- a/Assets/NaughtyAttributes/Scripts/Test/DropdownTest.cs
+++ b/Assets/NaughtyAttributes/Scripts/Test/DropdownTest.cs
@@ -7,6 +7,15 @@ namespace NaughtyAttributes.Test
     {
         [Dropdown("intValues")]
         public int intValue;
+        
+        [Dropdown("intValues", DisplayPrefix = "Number: ")]
+        public int prefixedIntValue;
+
+        [Dropdown("intValues", DisplaySuffix = " Megabyte(s)")]
+        public int suffixedIntValue;
+
+        [Dropdown("intValues", "Show "," Widgets")]
+        public int surroundedIntValue;
 
 #pragma warning disable 414
         private int[] intValues = new int[] { 1, 2, 3 };
@@ -20,6 +29,15 @@ namespace NaughtyAttributes.Test
     {
         [Dropdown("StringValues")]
         public string stringValue;
+        
+        [Dropdown("StringValues", DisplayPrefix = "Letter: ")]
+        public string prefixedStringValue;
+
+        [Dropdown("StringValues", DisplaySuffix = " Grade")]
+        public string suffixedStringValue;
+
+        [Dropdown("StringValues", "Hello ", " World")]
+        public string surroundedStringValue;
 
         private List<string> StringValues { get { return new List<string>() { "A", "B", "C" }; } }
 
@@ -31,6 +49,15 @@ namespace NaughtyAttributes.Test
     {
         [Dropdown("GetVectorValues")]
         public Vector3 vectorValue;
+        
+        [Dropdown("GetVectorValues", DisplayPrefix = "Go ")]
+        public Vector3 prefixedVectorValue;
+
+        [Dropdown("GetVectorValues", DisplaySuffix = " is the way!")]
+        public Vector3 suffixedVectorValue;
+
+        [Dropdown("GetVectorValues", "Go: ", ", now!")]
+        public Vector3 surroundedVectorValue;
 
         private DropdownList<Vector3> GetVectorValues()
         {


### PR DESCRIPTION
This just optionally modifies the text being drawn in the dropdown, so that the user can easily prefix or suffix options with "decoration".

My use case was to decorate a list of baud rates, but not wanting to have the entire setup with a `DropdownList<T>`:

![image](https://user-images.githubusercontent.com/602691/142646488-4a53243e-50b1-428e-af13-c43b4c62d792.png)

![image](https://user-images.githubusercontent.com/602691/142646578-661fbf42-aa40-4d3e-af3c-c6a06fe62734.png)

However, the prefix and suffix decorations _do_ still work with the `DropdownList<T>`:

![image](https://user-images.githubusercontent.com/602691/142646947-01d129bb-c4c9-4175-821e-79571f390ebe.png)
