### PR TITLE
multiple special drawers and an example

### DIFF
--- a/Assets/HexBrush.meta
+++ b/Assets/HexBrush.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 58559e5d504360e45bd26e9eb002d26f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HexBrush/Editor.meta
+++ b/Assets/HexBrush/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e672106ce5c8c094db31fe4c7aa2bf72
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HexBrush/Editor/HexBrush.meta
+++ b/Assets/HexBrush/Editor/HexBrush.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 640a2ad78a3a8284297ef637c5ec526d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HexBrush/Editor/HexBrush/HexBrushAdditive.cs
+++ b/Assets/HexBrush/Editor/HexBrush/HexBrushAdditive.cs
@@ -1,0 +1,35 @@
+using LoneTower.HexSystem;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+namespace LoneTower.EditorUtilis {
+
+	public class HexBrushAdditive : HexBrushLogic {
+		public HexBrushAdditive(List<HexVector> vv, BrushSettings data) : base(vv, data, true) { }
+
+		protected override void EndStroke(HexVector v) {
+			base.EndStroke(v);
+		}
+
+		protected override void StartStroke(HexVector obj) {
+			data.subtractive = EditorSceneInput.Instance.shiftPressed;
+		}
+
+		protected override void Stroke(HexVector v) {
+			List<HexVector> modified = new List<HexVector>();
+
+			foreach(HexVector a in GetBrush())
+				if(selection.Contains(a)) {
+					if(allowedArea != null) {
+						if(allowedArea.Contains(a))
+							modified.Add(a);
+					} else
+						modified.Add(a);
+				}
+			stroke?.Invoke(modified);
+		}
+	}
+}

--- a/Assets/HexBrush/Editor/HexBrush/HexBrushAdditive.cs.meta
+++ b/Assets/HexBrush/Editor/HexBrush/HexBrushAdditive.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1c1f8981622edcd4bb438b67c3ff0d52
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HexBrush/Editor/HexBrush/HexBrushLogic.cs
+++ b/Assets/HexBrush/Editor/HexBrush/HexBrushLogic.cs
@@ -1,0 +1,155 @@
+using LoneTower.HexSystem;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+namespace LoneTower.EditorUtilis {
+
+	public abstract class HexBrushLogic {
+
+		public List<HexVector> selection;
+		public Action OnStrokeEnd;
+		public Action<List<HexVector>> stroke;
+		public bool on = false;
+		public BrushSettings data;
+		public List<HexVector> allowedArea;
+
+		EditorHexPointer input;
+
+		public HexBrushLogic(List<HexVector> selection, BrushSettings data, bool continuous = false) {
+			this.selection = selection;
+			SceneView.duringSceneGui += SceneDraw;
+			if(continuous)
+				input = new EditorHexPointerContinuous();
+			else
+				input = new EditorHexPointer();
+		}
+
+		protected virtual void SceneDraw(SceneView obj) {
+			DrawSelection();
+			DrawBrush();
+			DrawPossible();
+		}
+
+
+
+		public virtual void Enable() {
+			on = true;
+			EditorSceneInput.Instance.inputInterception = true;
+			EditorSceneInput.Instance.MouseScroll += ChangeBrushSize;
+
+			input.OnPressed += StartStroke;
+			input.OnPressed += Stroke;
+			input.OnDrag += Stroke;
+			input.OnRelease += EndStroke;
+
+		}
+
+		public virtual void Disable() {
+			on = false;
+			EditorSceneInput.Instance.inputInterception = false;
+			EditorSceneInput.Instance.MouseScroll -= ChangeBrushSize;
+
+			input.OnPressed -= StartStroke;
+			input.OnPressed -= Stroke;
+			input.OnDrag -= Stroke;
+			input.OnRelease -= EndStroke;
+		}
+
+		//STROKE//////
+		protected abstract void StartStroke(HexVector obj);
+		protected abstract void Stroke(HexVector v);
+		protected virtual void EndStroke(HexVector v) {
+			OnStrokeEnd?.Invoke();
+		}
+		//STROKE//////
+
+		public void ClearSelection() {
+			data.subtractive = true;
+			stroke?.Invoke(selection);
+			selection.Clear();
+		}
+
+		public void DrawSelection() {
+			Color aaa = Color.blue;
+			aaa.a = 0.3f;
+			Handles.color = aaa;
+
+			foreach(HexVector v in selection) {
+				Handles.DrawSolidDisc(v.Cartesian, Vector3.up, 0.3f);
+			}
+		}
+		public void DrawBrush() {
+			if(!on)
+				return;
+			Color aaa;
+
+			if(selection.Contains(EditorSceneInput.Instance.MouseHexPosition)) {
+				aaa = Color.red;
+			} else
+				aaa = Color.green;
+
+			aaa.a = 0.2f;
+			Handles.color = aaa;
+
+			foreach(HexVector a in GetBrush()) {
+				Handles.DrawSolidDisc(a.Cartesian, Vector3.up, 0.3f);
+			}
+
+		}
+		private void DrawPossible() {
+			if(allowedArea == null)
+				return;
+
+			foreach(HexVector a in allowedArea) {
+				Handles.DrawAAPolyLine(10, circle(a.Cartesian, 0.3f, 10));
+			}
+		}
+		protected HexVector[] GetBrush() {
+			List<HexVector> v = new List<HexVector>();
+
+			v.Add(EditorSceneInput.Instance.MouseHexPosition);
+			for(int r = 1; r < data.size; r++) {
+				HexVector m = HexVector.up * r;
+				for(int i = 0; i < r * 6; i++) {
+					m = m.CircleRotate(1);
+					v.Add(EditorSceneInput.Instance.MouseHexPosition + m);
+				}
+			}
+			return v.ToArray();
+		}
+		protected virtual void ChangeBrushSize(float f) {
+			data.size += Math.Sign(f);
+			data.size = Mathf.Clamp(data.size, 0, 10);
+		}
+
+		public void Clear() {
+			Disable();
+			SceneView.duringSceneGui -= SceneDraw;
+		}
+
+		Vector3[] circle(Vector3 center, float radius, int points) {
+			Vector3[] c = new Vector3[points + 1];
+			for(int i = 0; i < points; i++) {
+				c[i] = center + Quaternion.AngleAxis((360f / points) * i, Vector3.up) * Vector3.forward * radius;
+			}
+			c[points] = center + Vector3.forward * radius;
+			return c;
+		}
+	}
+
+	public struct BrushSettings {
+		public bool subtractive;
+		public int size;
+		public float strength;
+
+		public BrushSettings(int size, float strength) {
+			this.subtractive = false;
+			this.size = size;
+			this.strength = strength;
+		}
+	}
+
+}

--- a/Assets/HexBrush/Editor/HexBrush/HexBrushLogic.cs.meta
+++ b/Assets/HexBrush/Editor/HexBrush/HexBrushLogic.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 93d32f13ca9bede419fda6b85f64cfb9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HexBrush/Editor/HexBrush/HexBrushMain.cs
+++ b/Assets/HexBrush/Editor/HexBrush/HexBrushMain.cs
@@ -1,0 +1,56 @@
+using LoneTower.HexSystem;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+namespace LoneTower.EditorUtilis {
+
+	public class HexBrushMain : HexBrushLogic {
+		public HexBrushMain(List<HexVector> vv, BrushSettings data) : base(vv, data) { }
+		protected override void StartStroke(HexVector obj) {
+			if(selection.Contains(obj)) {
+				data.subtractive = true;
+			} else
+				data.subtractive = false;
+		}
+
+		protected override void Stroke(HexVector v) {
+			List<HexVector> modifications = new List<HexVector>();
+
+			if(data.subtractive) {
+				foreach(HexVector a in GetBrush()) {
+					if(allowedArea != null) {
+						if(allowedArea.Contains(a))
+							if(selection.Contains(a)) {
+								modifications.Add(a);
+								selection.Remove(a);
+							}
+					} else
+					if(selection.Contains(a)) {
+						modifications.Add(a);
+						selection.Remove(a);
+					}
+				}
+			} else {
+				foreach(HexVector a in GetBrush()) {
+					if(allowedArea != null) {
+						if(allowedArea.Contains(a)) {
+							if(!selection.Contains(a)) {
+								selection.Add(a);
+								modifications.Add(a);
+							}
+						}
+					} else if(!selection.Contains(a)) {
+						selection.Add(a);
+						modifications.Add(a);
+					}
+				}
+			}
+			stroke?.Invoke(modifications);
+		}
+
+
+	}
+}

--- a/Assets/HexBrush/Editor/HexBrush/HexBrushMain.cs.meta
+++ b/Assets/HexBrush/Editor/HexBrush/HexBrushMain.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0c51902ec7f9fb8419cc8f985bfc1576
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HexBrush/Editor/HexBrush/HexBrushSingle.cs
+++ b/Assets/HexBrush/Editor/HexBrush/HexBrushSingle.cs
@@ -1,0 +1,26 @@
+using LoneTower.HexSystem;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+namespace LoneTower.EditorUtilis {
+
+	public class HexBrushSingle : HexBrushLogic {
+		public HexBrushSingle(List<HexVector> vv, BrushSettings data) : base(vv, data, true) { }
+		protected override void EndStroke(HexVector v) {
+			selection.Clear();
+			selection.Add(v);
+			OnStrokeEnd?.Invoke();
+		}
+
+		protected override void StartStroke(HexVector obj) {
+
+		}
+
+		protected override void Stroke(HexVector v) {
+
+		}
+	}
+}

--- a/Assets/HexBrush/Editor/HexBrush/HexBrushSingle.cs.meta
+++ b/Assets/HexBrush/Editor/HexBrush/HexBrushSingle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4a2e0f31983e2ea4998d32d053e9e431
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HexBrush/Editor/HexBrush/SerializedHexBrush.cs
+++ b/Assets/HexBrush/Editor/HexBrush/SerializedHexBrush.cs
@@ -1,0 +1,88 @@
+using LoneTower.EditorUtilis;
+using LoneTower.HexSystem;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+
+namespace LoneTower.EditorUtilis {
+
+	public class SerializedHexBrush : HexBrushMain {
+
+		SerializedObject prop;
+		string propName;
+
+		public SerializedHexBrush(string propName, SerializedObject prop, List<HexVector> vv, BrushSettings data) : base(vv, data) {
+			this.prop = prop;
+			this.propName = propName;
+		}
+		protected override void EndStroke(HexVector v) {
+			base.EndStroke(v);
+			HexArraySerializer.Serialize(propName, prop, selection);
+		}
+	}
+}
+public static class HexArraySerializer {
+
+	public static void Serialize(string propName, SerializedObject prop, List<HexVector> hex) {
+		if(EditorApplication.isPlayingOrWillChangePlaymode)
+			return;
+
+		prop.Update();
+		SerializedProperty array = prop.FindProperty(propName);
+		array.arraySize = hex.Count;
+		prop.ApplyModifiedProperties();
+		Undo.RecordObjects(prop.targetObjects, "stroke");
+		for(int i = 0; i < hex.Count; i++) {
+			SerializedProperty x = array.GetArrayElementAtIndex(i).FindPropertyRelative("x");
+			SerializedProperty y = array.GetArrayElementAtIndex(i).FindPropertyRelative("y");
+			x.intValue = hex[i].x;
+			y.intValue = hex[i].y;
+		}
+		prop.ApplyModifiedProperties();
+		EditorUtility.SetDirty(prop.targetObject);
+	}
+	public static void Serialize(SerializedProperty prop, List<HexVector> hex) {
+		if(EditorApplication.isPlayingOrWillChangePlaymode)
+			return;
+
+		prop.arraySize = hex.Count;
+		for(int i = 0; i < hex.Count; i++) {
+			SerializedProperty x = prop.GetArrayElementAtIndex(i).FindPropertyRelative("x");
+			SerializedProperty y = prop.GetArrayElementAtIndex(i).FindPropertyRelative("y");
+			x.intValue = hex[i].x;
+			y.intValue = hex[i].y;
+		}
+
+		prop.serializedObject.ApplyModifiedProperties();
+		EditorUtility.SetDirty(prop.serializedObject.targetObject);
+
+	}
+
+}
+public static class HexBrushGUIDrawer {
+	static int size = 30;
+	public static void Draw(string name, HexBrushLogic brush) {
+		EditorGUILayout.BeginHorizontal();
+
+		bool s = GUILayout.Toggle(brush.on, EditorGUIUtility.IconContent("Grid.PaintTool@2x"), "Button", GUILayout.Width(size), GUILayout.Height(size));
+		if(s != brush.on) {
+			if(s)
+				brush.Enable();
+			else
+				brush.Disable();
+		}
+
+
+		if(GUILayout.Button(EditorGUIUtility.IconContent("P4_DeletedLocal@2x"), GUILayout.Height(size), GUILayout.Width(size))) {
+			brush.ClearSelection();
+		}
+
+		EditorGUILayout.LabelField(name + ": " + brush.selection.Count);
+
+		EditorGUILayout.EndHorizontal();
+
+	}
+}

--- a/Assets/HexBrush/Editor/HexBrush/SerializedHexBrush.cs.meta
+++ b/Assets/HexBrush/Editor/HexBrush/SerializedHexBrush.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f1082d8a29ebe2849ba6f513948f0aec
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HexBrush/Editor/HexDrawer.cs
+++ b/Assets/HexBrush/Editor/HexDrawer.cs
@@ -1,0 +1,95 @@
+using LoneTower.EditorUtilis;
+using LoneTower.HexSystem;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEditor.UIElements;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+[CustomPropertyDrawer(typeof(HexVector))]
+public class HexDrawer : PropertyDrawer {
+	//bool state = false;
+	HexBrushLogic brush = new HexBrushSingle(new List<HexVector>(), new BrushSettings(1, 1));
+	SerializedProperty x;
+	SerializedProperty y;
+	bool changed = false;
+
+	public override void OnGUI(Rect rect, SerializedProperty property, GUIContent label) {
+
+
+		EditorGUI.BeginProperty(rect, label, property);
+		x = property.FindPropertyRelative("x");
+		y = property.FindPropertyRelative("y");
+		if(changed) {
+			changed = false;
+			x.intValue = brush.selection[0].x;
+			y.intValue = brush.selection[0].y;
+
+			EditorGUI.EndProperty();
+			return;
+		}
+		brush.selection = new List<HexVector>() { new HexVector(x.intValue, y.intValue) };
+		Rect input = new Rect(
+			rect.x,
+			rect.y,
+			rect.width, rect.height);
+
+		Vector2Int g = EditorGUI.Vector2IntField(input, label, new Vector2Int(x.intValue, y.intValue));
+
+		Rect button = new Rect(
+		rect.width - 30,
+		rect.y,
+		18, 18);
+
+
+		bool s = GUI.Toggle(button, brush.on, EditorGUIUtility.IconContent("Grid.PaintTool@2x"), "Button");
+		if(s != brush.on) {
+			if(s) {
+				brush.Enable();
+				brush.OnStrokeEnd = Serialize;
+				brush.selection = new List<HexVector>() { new HexVector(g.x, g.y) };
+			} else {
+
+				brush.Disable();
+				brush.OnStrokeEnd = null;
+				brush.selection.Clear();
+			}
+		}
+
+
+
+
+		if(brush.selection.Count == 0) {
+			x.intValue = g.x;
+			y.intValue = g.y;
+		} else {
+			x.intValue = brush.selection[0].x;
+			y.intValue = brush.selection[0].y;
+		}
+
+		EditorGUI.EndProperty();
+	}
+
+	public override float GetPropertyHeight(SerializedProperty property, GUIContent label) {
+		if(EditorGUIUtility.wideMode)
+			return 18;
+		else
+			return 18 * 2;
+
+	}
+
+
+	public void Serialize() {
+		Debug.Log("called");
+		x.intValue = brush.selection[0].x;
+		y.intValue = brush.selection[0].y;
+		EditorUtility.SetDirty(x.serializedObject.targetObject);
+		changed = true;
+		brush.Disable();
+
+		brush.OnStrokeEnd = null;
+
+
+	}
+}

--- a/Assets/HexBrush/Editor/HexDrawer.cs.meta
+++ b/Assets/HexBrush/Editor/HexDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 60df5f826a131b94aa58a70f49c880f0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HexBrush/LoneTower.HexBrush.asmdef
+++ b/Assets/HexBrush/LoneTower.HexBrush.asmdef
@@ -1,0 +1,17 @@
+{
+    "name": "LoneTower.HexBrush",
+    "rootNamespace": "",
+    "references": [
+        "GUID:60fd1960cd0079a4cb0401a37c2db3d4",
+        "GUID:5b34a38c2999c854cad4840282c17bc8"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/HexBrush/LoneTower.HexBrush.asmdef.meta
+++ b/Assets/HexBrush/LoneTower.HexBrush.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 825fd54a1be4dd7448e37859df8d2eb3
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HexBrush/Special.cs.meta
+++ b/Assets/HexBrush/Special.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7066ac01a8bdbd449b8b2fa957810f75
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HexSystem.meta
+++ b/Assets/HexSystem.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f73b717b901094c4f9d3cd9d6ef42a89
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HexSystem/Editor.meta
+++ b/Assets/HexSystem/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f5ad8857ca3d31c45aa2fdef54fe2ac7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HexSystem/Editor/EditorHexPointer.cs
+++ b/Assets/HexSystem/Editor/EditorHexPointer.cs
@@ -1,0 +1,67 @@
+using LoneTower.HexSystem;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace LoneTower.EditorUtilis {
+
+	public class EditorHexPointer {
+		public static EditorHexPointer Instance {
+			get {
+				if(instance == null)
+					instance = new EditorHexPointer();
+				return instance;
+			}
+		}
+		public static EditorHexPointer instance;
+
+		public Action<HexVector> OnPressed, OnDrag, OnRelease;
+		protected HexVector startPos;
+
+		public void Enable() {
+			EditorSceneInput.Instance.inputInterception = true;
+		}
+		public void Disable() {
+			EditorSceneInput.Instance.inputInterception = false;
+		}
+
+		private void Click() {
+			startPos = EditorSceneInput.Instance.MouseHexPosition;
+			OnPressed?.Invoke(startPos);
+		}
+
+		protected virtual void Pressing() {
+			HexVector v = EditorSceneInput.Instance.MouseHexPosition;
+			if(v == startPos)
+				return;
+			OnDrag?.Invoke(v);
+		}
+
+		private void Release() {
+			HexVector v = EditorSceneInput.Instance.MouseHexPosition;
+			OnRelease?.Invoke(v);
+		}
+
+		public EditorHexPointer() {
+			EditorSceneInput.Instance.MouseDown += Click;
+			EditorSceneInput.Instance.MousePressing += Pressing;
+			EditorSceneInput.Instance.MouseUp += Release;
+		}
+
+		~EditorHexPointer() {
+			EditorSceneInput.Instance.MouseDown -= Click;
+			EditorSceneInput.Instance.MousePressing -= Pressing;
+			EditorSceneInput.Instance.MouseUp -= Release;
+		}
+
+	}
+
+	public class EditorHexPointerContinuous : EditorHexPointer {
+		protected override void Pressing() {
+			HexVector v = EditorSceneInput.Instance.MouseHexPosition;
+			OnDrag?.Invoke(v);
+		}
+	}
+
+}

--- a/Assets/HexSystem/Editor/EditorHexPointer.cs.meta
+++ b/Assets/HexSystem/Editor/EditorHexPointer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6813fbd390c38254190055b6fc6e7597
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HexSystem/Editor/EditorSceneInput.cs
+++ b/Assets/HexSystem/Editor/EditorSceneInput.cs
@@ -1,0 +1,86 @@
+﻿using LoneTower.HexSystem;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+namespace LoneTower.EditorUtilis {
+	public class EditorSceneInput : Singleton<EditorSceneInput> {
+
+		public bool inputInterception;
+		public bool shiftPressed { get; private set; }
+		public event Action MouseDown, MouseUp, MousePressing, ShiftDown, ShiftUp;
+		public event Action<float> MouseScroll;
+		public event Action<Event> KeyDown;
+
+
+		bool LMBpressed = false;
+
+		public EditorSceneInput() {
+			SceneView.duringSceneGui += SceneFunc;
+		}
+
+		void SceneFunc(SceneView sceneView) {
+			if(!inputInterception)
+				return;
+
+			MouseInput(Event.current);
+			ShiftButton(Event.current);
+			if(Event.current.type == EventType.KeyDown) {
+				KeyDown?.Invoke(Event.current);
+			}
+		}
+
+		void MouseInput(Event e) {
+			HandleUtility.AddDefaultControl(GUIUtility.GetControlID(FocusType.Passive));//disables LBM 
+
+			if(e.type == EventType.MouseDown && e.button == 0) {
+				MouseDown?.Invoke();
+				LMBpressed = true;
+
+			} else if(e.type == EventType.MouseUp && e.button == 0) {
+				MouseUp?.Invoke();
+				LMBpressed = false;
+			}
+
+			if(LMBpressed) {
+				MousePressing?.Invoke();
+			}
+
+			if(e.type == EventType.ScrollWheel) {
+				MouseScroll?.Invoke(e.delta.y);
+				e.Use();
+			}
+		}
+
+		void ShiftButton(Event e) {
+			if(e.type == EventType.KeyDown && Event.current.keyCode == KeyCode.LeftShift) {
+				if(!shiftPressed) {
+
+					ShiftDown?.Invoke();
+					shiftPressed = true;
+				}
+			}
+			if(e.type == EventType.KeyUp && Event.current.keyCode == KeyCode.LeftShift) {
+				if(shiftPressed) {
+
+					ShiftUp?.Invoke();
+					shiftPressed = false;
+				}
+			}
+		}
+
+		public HexVector MouseHexPosition {
+			get {
+				Ray r = HandleUtility.GUIPointToWorldRay(Event.current.mousePosition);
+				float mltp = r.origin.y / r.direction.y;
+				Vector3 pos = r.origin - mltp * r.direction;
+
+				return HexVector.GetHex(pos);
+			}
+		}
+
+	}
+
+}

--- a/Assets/HexSystem/Editor/EditorSceneInput.cs.meta
+++ b/Assets/HexSystem/Editor/EditorSceneInput.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2bbe8d83c97a26848b6af60b4ab04637
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HexSystem/LoneTower.HexSystem.asmdef
+++ b/Assets/HexSystem/LoneTower.HexSystem.asmdef
@@ -1,0 +1,16 @@
+{
+    "name": "HexSystemAssembly",
+    "rootNamespace": "",
+    "references": [
+        "GUID:5b34a38c2999c854cad4840282c17bc8"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/HexSystem/LoneTower.HexSystem.asmdef.meta
+++ b/Assets/HexSystem/LoneTower.HexSystem.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 60fd1960cd0079a4cb0401a37c2db3d4
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HexSystem/Scripts.meta
+++ b/Assets/HexSystem/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 20f057b5a4e62c64e865b0489fe2f293
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HexSystem/Scripts/HexArray.cs
+++ b/Assets/HexSystem/Scripts/HexArray.cs
@@ -1,0 +1,137 @@
+using LoneTower.HexSystem;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[Serializable]
+public class HexArray<T> {
+	public readonly HexVector offset;
+	public T[,] data { get; private set; }
+
+	public HexArray(int minX, int maxX, int minY, int maxY) {
+		offset = new HexVector(-minX, -minY);
+		data = new T[maxX - minX, maxY - minY];
+	}
+	public HexArray(T[,] data, HexVector offset) {
+		this.data = data;
+		this.offset = offset;
+	}
+	public HexArray(int width, int heigth, HexVector offset) {
+		this.offset = offset;
+		data = new T[width, heigth];
+	}
+
+	public int width { get { return data.GetLength(0); } }
+	public int height { get { return data.GetLength(1); } }
+
+	public T GetVal(HexVector v) {
+		v += offset;
+		try {
+			return data[v.x, v.y];
+		} catch {
+			throw new Exception($"HexArray out of range. Size: ({data.GetLength(0)},{data.GetLength(1)}) requested: {(v - offset).ToShortString()}");
+		}
+	}
+
+	public void SetVal(HexVector v, T val) {
+		v += offset;
+		data[v.x, v.y] = val;
+	}
+
+	public static Texture2D MapFloat(HexArray<float> arr) {
+		Texture2D map = new Texture2D(arr.data.GetLength(0), arr.data.GetLength(1), TextureFormat.RGBA32, false);
+
+		arr.data[0, 0] = arr.offset.x;
+		arr.data[1, 0] = arr.offset.y;
+
+		List<byte> b = new List<byte>();
+
+
+		for(int y = 0; y < map.height; y++) {
+			for(int x = 0; x < map.width; x++) {
+				b.AddRange(BitConverter.GetBytes(arr.data[x, y]));
+			}
+		}
+
+		map.SetPixelData(b.ToArray(), 0, 0);
+		map.filterMode = FilterMode.Point;
+		map.Apply(updateMipmaps: false);
+		return map;
+	}
+
+	public static Texture2D MapInt(HexArray<int> arr) {
+		Texture2D map = new Texture2D(arr.data.GetLength(0), arr.data.GetLength(1), TextureFormat.RGBA32, false);
+
+		arr.data[0, 0] = arr.offset.x;
+		arr.data[1, 0] = arr.offset.y;
+
+		List<byte> b = new List<byte>();
+
+
+		for(int y = 0; y < map.height; y++) {
+			for(int x = 0; x < map.width; x++) {
+				b.AddRange(BitConverter.GetBytes(arr.data[x, y]));
+			}
+		}
+
+		map.SetPixelData(b.ToArray(), 0, 0);
+		map.filterMode = FilterMode.Point;
+		map.Apply(updateMipmaps: false);
+		return map;
+	}
+
+	public static HexArray<float> FromFloatMap(Texture2D map) {
+		int counter = 0;
+
+		byte[] b = map.GetRawTextureData();
+		HexVector offset = new HexVector((int)BitConverter.ToSingle(b, 0), (int)BitConverter.ToSingle(b, 4));
+
+		HexArray<float> arr = new HexArray<float>(map.width, map.height, offset);
+
+		for(int y = 0; y < map.height; y++) {
+			for(int x = 0; x < map.width; x++) {
+				arr.data[x, y] = BitConverter.ToSingle(b, counter);
+				counter += 4;
+			}
+		}
+
+		arr.data[0, 0] = arr.data[0, 3];
+		arr.data[1, 0] = arr.data[0, 3];
+
+		return arr;
+	}
+
+	public static HexArray<int> FromIntMap(Texture2D map) {
+		int counter = 0;
+
+		byte[] b = map.GetRawTextureData();
+
+		HexVector offset = new HexVector((int)BitConverter.ToInt32(b, 0), BitConverter.ToInt32(b, 4));
+
+		HexArray<int> arr = new HexArray<int>(map.width, map.height, offset);
+		for(int y = 0; y < map.height; y++) {
+			for(int x = 0; x < map.width; x++) {
+				arr.data[x, y] = BitConverter.ToInt32(b, counter);
+				counter += 4;
+			}
+		}
+
+		arr.data[0, 0] = arr.data[0, 3];
+		arr.data[1, 0] = arr.data[0, 3];
+
+		return arr;
+	}
+
+	public static HexArray<bool> FloatToBool(HexArray<float> g) {
+
+		HexArray<bool> v = new HexArray<bool>(g.width, g.height, g.offset);
+		for(int x = 0; x < g.width; x++) {
+			for(int y = 0; y < g.height; y++) {
+				v.data[x, y] = g.data[x, y] > 0;
+			}
+		}
+		return v;
+	}
+
+}

--- a/Assets/HexSystem/Scripts/HexArray.cs.meta
+++ b/Assets/HexSystem/Scripts/HexArray.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9df1d194286d5ed4690fb8d9b7c7378e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HexSystem/Scripts/HexSystem.cs
+++ b/Assets/HexSystem/Scripts/HexSystem.cs
@@ -1,0 +1,414 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace LoneTower.HexSystem {
+	[System.Serializable]
+	public struct HexData {
+		public static readonly float hexRatio = 0.86603f;
+		public static readonly float outerRadius = 0.5f;
+		public static readonly float innerRadius = outerRadius * hexRatio;
+		public static readonly float levelHeigth = 0.6f;
+
+		public static readonly Vector3 yAxis = Vector3.forward;
+		public static readonly Vector3 xAxis = Quaternion.AngleAxis(60, Vector3.up) * yAxis;
+		public static readonly Vector3 ortho = Vector3.Cross(yAxis, xAxis);
+
+	}
+
+	[System.Serializable]
+	public struct HexVector {
+		public enum direction { up, upR, downR, down, downL, upL, zero }
+
+		public int x, y;
+
+		public int z { get { return -x - y; } }
+		public int magnitude {
+			get {
+				return (Mathf.Abs(x) + Mathf.Abs(y) + Mathf.Abs(z)) / 2;
+			}
+		}
+
+
+		public int angle {
+			get {
+				return GetRotation(up, this.normalize);
+			}
+		}
+
+		public HexVector(int x, int y) {
+			this.x = x;
+			this.y = y;
+		}
+
+		public HexVector(Vector3 pos) {
+			this = GetHex(pos);
+		}
+
+		public override string ToString() {
+			return "HexVector(" + x + ", " + y + ")";
+		}
+		public string ToShortString() {
+			return "(" + x + ", " + y + ")";
+		}
+
+		public bool TryParse(string val, out HexVector v) {
+			if(val.Contains("HexVector"))
+				val = val.Remove(0, "HexVector".Length);
+
+			val.Trim('(', ')', ',');
+			string[] xy = val.Split(' ');
+			int x = int.Parse(xy[0]);
+			int y = int.Parse(xy[1]);
+			v = new HexVector(x, y);
+			return true;
+		}
+
+		public Vector3 Cartesian {
+			get {
+				return (HexData.xAxis * x + HexData.yAxis * y) * HexData.innerRadius * 2;
+			}
+		}
+
+		public HexVector Rotate(int tiles) {
+			tiles = tiles % 6;
+
+
+			int xR = x,
+				yR = y,
+				zR = z;
+			int xTemp, yTemp, zTemp;
+			if(tiles >= 0) {
+				for(int i = 0; i < tiles; i++) {
+					xTemp = xR;
+					yTemp = yR;
+					zTemp = zR;
+
+					xR = -zTemp;
+					yR = -xTemp;
+					zR = -yTemp;
+
+				}
+			} else {
+				for(int i = 0; i < -tiles; i++) {
+					xTemp = xR;
+					yTemp = yR;
+					zTemp = zR;
+
+					xR = -yTemp;
+					yR = -zTemp;
+					zR = -xTemp;
+
+				}
+			}
+			return new HexVector(xR, yR);
+		}
+
+		public direction GetDirection() {
+			if(this == HexVector.up)
+				return direction.up;
+			if(this == downR)
+				return direction.downR;
+			if(this == upR)
+				return direction.upR;
+			if(this == -upR)
+				return direction.downL;
+			if(this == -downR)
+				return direction.upL;
+			if(this == -up)
+				return direction.down;
+			return direction.zero;
+		}
+
+		public HexVector CircleRotate(int tiles) {
+			int d = magnitude;
+			HexVector g = this;
+			//skrót przez rotację o pełne hexy
+
+			for(int i = 0; i < tiles; i++) {
+				if(Mathf.Abs(g.x) == d) {
+					if(Mathf.Abs(g.y) == d) {
+						g += downL * Math.Sign(g.x);
+						continue;
+					}
+					g += down * Math.Sign(g.x);
+					continue;
+				}
+
+				if(Mathf.Abs(g.y) == d) {
+					if(Mathf.Abs(g.z) == d) {
+						g += downR * Math.Sign(g.y);
+						continue;
+					}
+					g += upR * Math.Sign(g.y);
+					continue;
+				}
+				g += downR * Math.Sign(g.y);
+			}
+
+
+			for(int i = 0; i > tiles; i--) {
+
+				if(Mathf.Abs(g.y) == d) {
+					if(Mathf.Abs(g.x) == d) {
+						g += up * Math.Sign(g.x);
+						continue;
+					}
+					g += downL * Math.Sign(g.y);
+					continue;
+				}
+				if(Mathf.Abs(g.x) == d) {
+					if(Mathf.Abs(g.z) == d) {
+						g += upL * Math.Sign(g.x);
+						continue;
+					}
+					g += up * Math.Sign(g.x);
+					continue;
+				}
+
+				g += upL * Math.Sign(g.y);
+			}
+
+			return g;
+
+		}
+
+		public HexVector normalize {
+			get {
+				return GetHex(Cartesian.normalized);
+				//return new HexVector(Mathf.Clamp(this.x, -1, 1), Mathf.Clamp(this.y, -1, 1));
+			}
+		}
+		public bool CanNormalize() {
+			if(x == 0 || y == 0 || z == 0)
+				return true;
+			else
+				return false;
+		}
+		public Vector3 GetCorner(int index) {
+
+			return Cartesian + Quaternion.AngleAxis(-30 + index * 60, HexData.ortho) * (HexData.yAxis * HexData.outerRadius);
+		}
+
+		public Vector3 GetEdgeCenter(int index) {
+			return Cartesian + Quaternion.AngleAxis(-60 * index, HexData.ortho) * (HexData.yAxis * HexData.innerRadius);
+		}
+
+		public HexVector[] subdivide {
+			get {
+				HexVector[] p = new HexVector[2];
+				p[0] = new HexVector(x / 2, 0);
+				p[1] = new HexVector(0, y / 2);
+
+				p[0].y = y - p[1].y;
+				p[1].x = x - p[0].x;
+				//p[1] = new HexVector(x - p[0].x, y - p[0].y);
+				return p;
+			}
+		}
+
+
+		//statics
+		public readonly static HexVector zero = new HexVector(0, 0);
+		public readonly static HexVector up = new HexVector(0, 1);
+		public readonly static HexVector down = new HexVector(0, -1);
+
+		public readonly static HexVector upR = new HexVector(1, 0);
+		public readonly static HexVector upL = new HexVector(-1, 1);
+
+		public readonly static HexVector downL = new HexVector(-1, 0);
+		public readonly static HexVector downR = new HexVector(1, -1);
+
+
+		public static HexVector operator +(HexVector a, HexVector b) {
+			return new HexVector(a.x + b.x, a.y + b.y);
+		}
+		public static HexVector operator -(HexVector a, HexVector b) {
+			return new HexVector(a.x - b.x, a.y - b.y);
+		}
+		public static HexVector operator -(HexVector a) {
+			return new HexVector(-a.x, -a.y);
+		}
+		public static HexVector operator *(HexVector a, int v) {
+			return new HexVector(a.x * v, a.y * v);
+		}
+
+		public static bool operator ==(HexVector a, HexVector b) {
+			return (a.x == b.x && a.y == b.y);
+		}
+		public static bool operator !=(HexVector a, HexVector b) {
+			return !(a.x == b.x && a.y == b.y);
+		}
+
+		public static explicit operator Vector2Int(HexVector v) {
+			return new Vector2Int(v.x, v.y);
+		}
+
+		public static HexVector GetHex(Vector3 pos) {
+
+			float y = Vector3.Dot(pos, HexData.yAxis) / (HexData.innerRadius * 2);
+			float z = -y;
+
+			float offset = pos.x / (HexData.outerRadius * 3);
+
+			y -= offset;
+			z -= offset;
+
+			float x = -z - y;
+
+
+
+			int iX = Mathf.RoundToInt(x);
+			int iY = Mathf.RoundToInt(y);
+			int iZ = Mathf.RoundToInt(z);
+
+			if(iX + iY + iZ != 0) {
+				float dX = Mathf.Abs(x - iX);
+				float dY = Mathf.Abs(y - iY);
+				float dZ = Mathf.Abs(z - iZ);
+
+				if(dX > dY && dX > dZ) {
+					iX = -iY - iZ;
+				} else if(dY > dZ) {
+					iY = -iZ - iX;
+				}
+			}
+
+
+			return new HexVector(iX, iY);
+		}
+
+		public static HexVector Direction(Vector3 v, int row) {
+			v = Vector3.ProjectOnPlane(v, HexData.ortho).normalized * HexData.hexRatio * row;
+			return GetHex(v);      //nieładnie :/ 
+		}
+
+		public static Vector3 SnapDirection(Vector3 v) {
+			return (Direction(v, 1)).Cartesian;
+		}
+
+		public static Quaternion HexRotation(int v, int row) {
+			return Quaternion.AngleAxis(v * 60f / row, HexData.ortho);
+		}
+		public static Vector3 Snap(Vector3 pos) {
+			return (GetHex(pos)).Cartesian;
+		}
+		public Quaternion Rotation {
+			get {
+				return Quaternion.LookRotation(this.Cartesian.normalized, HexData.ortho);
+			}
+		}
+		public static int GetRotation(HexVector r, HexVector v) {
+
+			if(r == v)
+				return 0;
+
+			for(int i = 1; i < 4; i++) {
+				r = r.Rotate(1);
+				if(r == v)
+					return i;
+			}
+
+			for(int i = 0; i < 2; i++) {
+				r = r.Rotate(1);
+				if(r == v)
+					return i - 2;
+			}
+
+			return 0;
+		}
+
+		public override bool Equals(object obj) {
+			if(!(obj is HexVector)) {
+				return false;
+			}
+
+			var vector = (HexVector)obj;
+			return x == vector.x &&
+				   y == vector.y;
+		}
+
+		public override int GetHashCode() {
+			var hashCode = -1476677902;
+			hashCode = hashCode * -1521134295 + x.GetHashCode();
+			hashCode = hashCode * -1521134295 + y.GetHashCode();
+			return hashCode;
+		}
+
+		public static Quaternion SnappedRotation(Transform t) {
+			return Quaternion.LookRotation(SnapDirection(t.forward));
+		}
+
+		public static HexVector[] Line(HexVector from, HexVector to) {
+			HexVector l = to - from;
+			if(l == HexVector.zero)
+				return new HexVector[] { from };
+
+			Vector3 step = l.Cartesian / l.magnitude;
+			HexVector[] points = new HexVector[l.magnitude + 1];
+			for(int i = 0; i < l.magnitude + 1; i++) {
+				points[i] = from + GetHex(step * (i));
+			}
+			return points;
+		}
+
+		public static HexVector[] neighbours = new HexVector[]{
+		up, upR, downR, down, downL,upL    };
+
+	}
+	public struct HexBorder {
+		public int value { get; private set; }
+		public HexBorder(HexVector[] open) {
+			value = 0b00111111;
+			foreach(HexVector a in open) {
+				value &= ~DirToBorder[a];
+			}
+		}
+		public HexBorder(int val) {
+			value = val;
+		}
+
+		public void Add(HexVector v) {
+			value |= DirToBorder[v];
+		}
+		public void Remove(HexVector v) {
+			value &= ~DirToBorder[v];
+		}
+		public bool Allowed(HexVector v) {
+			int s = (DirToBorder[v] & value);
+			return s != 0;
+		}
+
+		static Dictionary<HexVector, byte> DirToBorder = new Dictionary<HexVector, byte> { // równiedobrze można by brać rotację wektora i przekęcać o << 1 
+		{ HexVector.zero,   0b0     },
+		{ HexVector.up,     0b1     },
+		{ HexVector.upR,    0b10    },
+		{ HexVector.downR,  0b100   },
+		{ HexVector.down,   0b1000  },
+		{ HexVector.downL,  0b10000 },
+		{ HexVector.upL,    0b100000},
+	};
+
+
+	}
+
+	/*
+	 public static int[] options = new int[] {
+			0b000000,
+			0b000001,
+			0b000011,
+			0b000111,
+			0b001111,
+			0b011111 ,
+
+			0b000101,
+			0b001101,
+			0b011101,
+			0b010101,
+			0b001001,
+			0b001011,
+			0b011011,
+			0b111111
+		};
+	*/
+}

--- a/Assets/HexSystem/Scripts/HexSystem.cs.meta
+++ b/Assets/HexSystem/Scripts/HexSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8366e629b5de9a947ab2215e4973ac7d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HexSystem/Singleton.cs
+++ b/Assets/HexSystem/Singleton.cs
@@ -1,0 +1,15 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public abstract class Singleton<T> where T : class, new() {
+
+	public static T Instance {
+		get {
+			if(instance == null)
+				instance = new T();
+			return instance;
+		}
+	}
+	static T instance;
+}

--- a/Assets/HexSystem/Singleton.cs.meta
+++ b/Assets/HexSystem/Singleton.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ef07c70748d60f0498cf413714ca4d09
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HexSystem/SingletonBehavior.cs
+++ b/Assets/HexSystem/SingletonBehavior.cs
@@ -1,0 +1,18 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public abstract class SingletonBehavior<T> : MonoBehaviour where T : MonoBehaviour {
+
+	public static T Instance { get; protected set; }
+
+	protected virtual void Awake() {
+		if(Instance == null)
+			Instance = this as T;
+		else {
+			Debug.Log("Doubled singleton: " + typeof(T).ToString());
+			Destroy(this);
+		}
+	}
+
+}

--- a/Assets/HexSystem/SingletonBehavior.cs.meta
+++ b/Assets/HexSystem/SingletonBehavior.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 92028302eef51a44ea520ebbeef6fec9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HexTest.cs
+++ b/Assets/HexTest.cs
@@ -1,0 +1,13 @@
+using NaughtyAttributes;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class HexTest : MonoBehaviour {
+
+	[HexBrushAttribute]
+	public HexVector[] TestArray;
+
+	[HexBrushAttribute]
+	public HexVector[] SecondArray;
+}

--- a/Assets/HexTest.cs.meta
+++ b/Assets/HexTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c45c36fae0e66d64ca964789521dbed5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/NaughtyAttributes/Samples/DemoScene.meta
+++ b/Assets/NaughtyAttributes/Samples/DemoScene.meta
@@ -2,7 +2,7 @@ fileFormatVersion: 2
 guid: afb4c815411c28b449e61fbaa1a8bfa3
 folderAsset: yes
 timeCreated: 1507995550
-licenseType: Free
+licenseType: Store
 DefaultImporter:
   externalObjects: {}
   userData: 

--- a/Assets/NaughtyAttributes/Samples/DemoScene/DemoScene.unity
+++ b/Assets/NaughtyAttributes/Samples/DemoScene/DemoScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657874, g: 0.49641258, b: 0.5748172, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -201,23 +201,32 @@ MonoBehaviour:
   enable1: 0
   enable2: 0
   enum1: 0
+  enum2: 0
   enableIfAll: 
   enableIfAny: 
   enableIfEnum: 
+  enableIfEnumFlag: 
+  enableIfEnumFlagMulti: 
   nest1:
     enable1: 1
     enable2: 0
     enum1: 0
+    enum2: 0
     enableIfAll: 1
     enableIfAny: 2
     enableIfEnum: 0
+    enableIfEnumFlag: 0
+    enableIfEnumFlagMulti: 0
     nest2:
       enable1: 1
       enable2: 1
       enum1: 0
+      enum2: 0
       enableIfAll: {x: 0.25, y: 0.75}
       enableIfAny: {x: 0.25, y: 0.75}
       enableIfEnum: {x: 0.25, y: 0.75}
+      enableIfEnumFlag: {x: 0, y: 0}
+      enableIfEnumFlagMulti: {x: 0, y: 0}
 --- !u!114 &114650326
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -233,23 +242,32 @@ MonoBehaviour:
   disable1: 0
   disable2: 0
   enum1: 0
+  enum2: 0
   disableIfAll: 
   disableIfAny: 
   disableIfEnum: 
+  disableIfEnumFlag: 
+  disableIfEnumFlagMulti: 
   nest1:
     disable1: 1
     disable2: 0
     enum1: 0
+    enum2: 0
     disableIfAll: 1
     disableIfAny: 2
     disableIfEnum: 3
+    disableIfEnumFlag: 0
+    disableIfEnumFlagMulti: 0
     nest2:
       disable1: 1
       disable2: 1
       enum1: 0
+      enum2: 0
       enableIfAll: {x: 0.25, y: 0.75}
       enableIfAny: {x: 0.25, y: 0.75}
       enableIfEnum: {x: 0.25, y: 0.75}
+      disableIfEnumFlag: {x: 0, y: 0}
+      disableIfEnumFlagMulti: {x: 0, y: 0}
 --- !u!1 &155697335
 GameObject:
   m_ObjectHideFlags: 0
@@ -346,6 +364,1783 @@ MonoBehaviour:
     readOnlyFloat: 3.14
     nest2:
       readOnlyString: 
+--- !u!1 &339123587
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 339123589}
+  - component: {fileID: 339123588}
+  m_Layer: 0
+  m_Name: HexArrayTest
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &339123588
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 339123587}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c45c36fae0e66d64ca964789521dbed5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  TestArray:
+  - x: -17
+    y: 15
+  - x: -16
+    y: 15
+  - x: -16
+    y: 14
+  - x: -17
+    y: 14
+  - x: -18
+    y: 15
+  - x: -18
+    y: 16
+  - x: -17
+    y: 16
+  - x: -15
+    y: 14
+  - x: -15
+    y: 13
+  - x: -16
+    y: 13
+  - x: -14
+    y: 13
+  - x: -15
+    y: 12
+  - x: -13
+    y: 13
+  - x: -14
+    y: 14
+  - x: -11
+    y: 12
+  - x: -12
+    y: 13
+  - x: -10
+    y: 11
+  - x: -10
+    y: 10
+  - x: -9
+    y: 11
+  - x: -9
+    y: 10
+  - x: -10
+    y: 12
+  - x: -8
+    y: 10
+  - x: -8
+    y: 9
+  - x: -9
+    y: 9
+  - x: -7
+    y: 10
+  - x: -7
+    y: 9
+  - x: -8
+    y: 11
+  - x: -6
+    y: 9
+  - x: -6
+    y: 8
+  - x: -7
+    y: 8
+  - x: -5
+    y: 9
+  - x: -5
+    y: 8
+  - x: -6
+    y: 10
+  - x: -13
+    y: 12
+  - x: -12
+    y: 12
+  - x: -12
+    y: 11
+  - x: -13
+    y: 11
+  - x: -14
+    y: 12
+  - x: -11
+    y: 11
+  - x: -11
+    y: 10
+  - x: -12
+    y: 10
+  - x: -11
+    y: 9
+  - x: -12
+    y: 9
+  - x: -13
+    y: 10
+  - x: -12
+    y: 7
+  - x: -11
+    y: 7
+  - x: -11
+    y: 6
+  - x: -12
+    y: 6
+  - x: -13
+    y: 7
+  - x: -13
+    y: 8
+  - x: -12
+    y: 8
+  - x: -11
+    y: 5
+  - x: -12
+    y: 5
+  - x: -13
+    y: 6
+  - x: -11
+    y: 4
+  - x: -12
+    y: 4
+  - x: -13
+    y: 5
+  - x: -13
+    y: 4
+  - x: -14
+    y: 5
+  - x: -14
+    y: 6
+  - x: -11
+    y: 3
+  - x: -12
+    y: 3
+  - x: -13
+    y: 3
+  - x: -14
+    y: 4
+  - x: -11
+    y: 2
+  - x: -12
+    y: 2
+  - x: -13
+    y: 2
+  - x: -14
+    y: 3
+  - x: -11
+    y: 1
+  - x: -12
+    y: 1
+  - x: -13
+    y: 1
+  - x: -14
+    y: 2
+  - x: -11
+    y: 0
+  - x: -12
+    y: 0
+  - x: -1
+    y: 7
+  - x: 0
+    y: 7
+  - x: 0
+    y: 6
+  - x: -1
+    y: 6
+  - x: -2
+    y: 7
+  - x: -2
+    y: 8
+  - x: -1
+    y: 8
+  - x: 0
+    y: 5
+  - x: -1
+    y: 5
+  - x: -2
+    y: 6
+  - x: 0
+    y: 4
+  - x: -1
+    y: 4
+  - x: -2
+    y: 5
+  - x: 0
+    y: 3
+  - x: -1
+    y: 3
+  - x: -2
+    y: 4
+  - x: 0
+    y: 2
+  - x: -1
+    y: 2
+  - x: -2
+    y: 3
+  - x: 0
+    y: 1
+  - x: -1
+    y: 1
+  - x: -2
+    y: 2
+  - x: 0
+    y: 0
+  - x: -1
+    y: 0
+  - x: -2
+    y: 1
+  - x: 0
+    y: -1
+  - x: -1
+    y: -1
+  - x: -2
+    y: 0
+  - x: 0
+    y: -2
+  - x: -1
+    y: -2
+  - x: -2
+    y: -1
+  - x: -2
+    y: -2
+  - x: -3
+    y: -1
+  - x: -3
+    y: 0
+  - x: -1
+    y: -3
+  - x: -2
+    y: -3
+  - x: -3
+    y: -2
+  - x: -1
+    y: -4
+  - x: -2
+    y: -4
+  - x: -3
+    y: -3
+  - x: -1
+    y: -5
+  - x: -2
+    y: -5
+  - x: -3
+    y: -4
+  - x: -1
+    y: -6
+  - x: -2
+    y: -6
+  - x: -3
+    y: -5
+  - x: -1
+    y: -7
+  - x: -2
+    y: -7
+  - x: -3
+    y: -6
+  - x: -3
+    y: -7
+  - x: -4
+    y: -6
+  - x: -4
+    y: -5
+  - x: -4
+    y: -4
+  - x: -4
+    y: -3
+  - x: -4
+    y: -2
+  - x: -4
+    y: -1
+  - x: 1
+    y: -1
+  - x: 1
+    y: -2
+  - x: 2
+    y: -2
+  - x: 2
+    y: -3
+  - x: 1
+    y: -3
+  - x: 3
+    y: -2
+  - x: 3
+    y: -3
+  - x: 2
+    y: -1
+  - x: 4
+    y: -3
+  - x: 4
+    y: -4
+  - x: 3
+    y: -4
+  - x: 5
+    y: -3
+  - x: 5
+    y: -4
+  - x: 4
+    y: -2
+  - x: 5
+    y: -5
+  - x: 4
+    y: -5
+  - x: 6
+    y: -4
+  - x: 6
+    y: -5
+  - x: 6
+    y: -6
+  - x: 5
+    y: -6
+  - x: 6
+    y: -7
+  - x: 5
+    y: -7
+  - x: 4
+    y: -6
+  - x: 6
+    y: -8
+  - x: 5
+    y: -8
+  - x: 4
+    y: -7
+  - x: 6
+    y: -9
+  - x: 5
+    y: -9
+  - x: 4
+    y: -8
+  - x: 11
+    y: -11
+  - x: 12
+    y: -11
+  - x: 12
+    y: -12
+  - x: 11
+    y: -12
+  - x: 10
+    y: -11
+  - x: 10
+    y: -10
+  - x: 11
+    y: -10
+  - x: 12
+    y: -10
+  - x: 10
+    y: -9
+  - x: 11
+    y: -9
+  - x: 9
+    y: -9
+  - x: 9
+    y: -8
+  - x: 10
+    y: -8
+  - x: 9
+    y: -7
+  - x: 9
+    y: -6
+  - x: 10
+    y: -5
+  - x: 11
+    y: -5
+  - x: 9
+    y: -5
+  - x: 9
+    y: -4
+  - x: 10
+    y: -4
+  - x: 12
+    y: -5
+  - x: 11
+    y: -4
+  - x: 12
+    y: -4
+  - x: 10
+    y: -3
+  - x: 11
+    y: -3
+  - x: 13
+    y: -5
+  - x: 12
+    y: -3
+  - x: 18
+    y: -4
+  - x: 18
+    y: -5
+  - x: 17
+    y: -3
+  - x: 19
+    y: -5
+  - x: 19
+    y: -6
+  - x: 18
+    y: -6
+  - x: 20
+    y: -5
+  - x: 20
+    y: -6
+  - x: 19
+    y: -4
+  - x: 21
+    y: -6
+  - x: 21
+    y: -7
+  - x: 20
+    y: -7
+  - x: 19
+    y: -7
+  - x: 20
+    y: -8
+  - x: 19
+    y: -8
+  - x: 18
+    y: -7
+  - x: 20
+    y: -9
+  - x: 19
+    y: -9
+  - x: 18
+    y: -8
+  - x: 21
+    y: -9
+  - x: 21
+    y: -10
+  - x: 18
+    y: -9
+  - x: 20
+    y: -13
+  - x: 19
+    y: -13
+  - x: 18
+    y: -12
+  - x: 18
+    y: -13
+  - x: 16
+    y: -8
+  - x: 17
+    y: -9
+  - x: 18
+    y: -10
+  - x: 18
+    y: -11
+  - x: 12
+    y: -9
+  - x: 12
+    y: -8
+  - x: 12
+    y: -7
+  - x: 13
+    y: -7
+  - x: 14
+    y: -7
+  - x: 15
+    y: -7
+  - x: 16
+    y: -7
+  - x: 17
+    y: -8
+  - x: 19
+    y: -10
+  - x: 19
+    y: -11
+  - x: 19
+    y: -12
+  - x: 19
+    y: -14
+  - x: 18
+    y: -14
+  - x: 11
+    y: -8
+  - x: 11
+    y: -7
+  - x: 11
+    y: -6
+  - x: 12
+    y: -6
+  - x: 13
+    y: -6
+  - x: 14
+    y: -6
+  - x: 17
+    y: -7
+  - x: 20
+    y: -10
+  - x: 20
+    y: -11
+  - x: 20
+    y: -12
+  - x: 20
+    y: -14
+  - x: 20
+    y: -15
+  - x: 19
+    y: -15
+  - x: 18
+    y: -15
+  - x: 10
+    y: -7
+  - x: 10
+    y: -6
+  - x: 21
+    y: -11
+  - x: 21
+    y: -12
+  - x: 21
+    y: -13
+  - x: 21
+    y: -14
+  - x: 21
+    y: -15
+  - x: 21
+    y: -16
+  - x: 20
+    y: -16
+  - x: 19
+    y: -16
+  - x: 18
+    y: -16
+  - x: 12
+    y: -13
+  - x: 9
+    y: -10
+  - x: 9
+    y: -3
+  - x: 21
+    y: -8
+  - x: 9
+    y: -2
+  - x: 10
+    y: -2
+  - x: 11
+    y: -2
+  - x: 12
+    y: -2
+  - x: 16
+    y: -2
+  - x: 9
+    y: -1
+  - x: 10
+    y: -1
+  - x: 11
+    y: -1
+  - x: 12
+    y: -1
+  - x: 13
+    y: -1
+  - x: 14
+    y: -1
+  - x: 15
+    y: -1
+  - x: 9
+    y: 0
+  - x: 10
+    y: 0
+  - x: 11
+    y: 0
+  - x: 12
+    y: 0
+  - x: 13
+    y: 0
+  - x: 14
+    y: 0
+  - x: 15
+    y: 0
+  - x: 16
+    y: -1
+  - x: 17
+    y: -2
+  - x: 18
+    y: -3
+  - x: 8
+    y: -5
+  - x: 8
+    y: -4
+  - x: 8
+    y: -3
+  - x: 8
+    y: -2
+  - x: 8
+    y: -1
+  - x: 8
+    y: 0
+  - x: 8
+    y: 1
+  - x: 9
+    y: 1
+  - x: 10
+    y: 1
+  - x: 11
+    y: 1
+  - x: 12
+    y: 1
+  - x: 13
+    y: 1
+  - x: 14
+    y: 1
+  - x: 16
+    y: 0
+  - x: 17
+    y: -1
+  - x: 18
+    y: -2
+  - x: 19
+    y: -3
+  - x: 20
+    y: -4
+  - x: 21
+    y: -5
+  - x: 15
+    y: 1
+  - x: 8
+    y: 2
+  - x: 9
+    y: 2
+  - x: 10
+    y: 2
+  - x: 11
+    y: 2
+  - x: 12
+    y: 2
+  - x: 13
+    y: 2
+  - x: 14
+    y: 2
+  - x: 16
+    y: 1
+  - x: 17
+    y: 0
+  - x: 18
+    y: -1
+  - x: 19
+    y: -2
+  - x: 20
+    y: -3
+  - x: 21
+    y: -4
+  - x: 15
+    y: 2
+  - x: 28
+    y: -20
+  - x: 29
+    y: -20
+  - x: 29
+    y: -21
+  - x: 28
+    y: -21
+  - x: 27
+    y: -20
+  - x: 27
+    y: -19
+  - x: 28
+    y: -19
+  - x: 29
+    y: -19
+  - x: 30
+    y: -20
+  - x: 30
+    y: -21
+  - x: 30
+    y: -22
+  - x: 29
+    y: -22
+  - x: 28
+    y: -22
+  - x: 27
+    y: -21
+  - x: 26
+    y: -20
+  - x: 26
+    y: -19
+  - x: 26
+    y: -18
+  - x: 27
+    y: -18
+  - x: 28
+    y: -18
+  - x: 29
+    y: -18
+  - x: 30
+    y: -19
+  - x: 26
+    y: -17
+  - x: 27
+    y: -17
+  - x: 28
+    y: -17
+  - x: 25
+    y: -18
+  - x: 25
+    y: -17
+  - x: 25
+    y: -16
+  - x: 26
+    y: -16
+  - x: 27
+    y: -16
+  - x: 28
+    y: -16
+  - x: 29
+    y: -17
+  - x: 25
+    y: -15
+  - x: 26
+    y: -15
+  - x: 27
+    y: -15
+  - x: 28
+    y: -15
+  - x: 29
+    y: -16
+  - x: 25
+    y: -14
+  - x: 26
+    y: -14
+  - x: 27
+    y: -14
+  - x: 26
+    y: -13
+  - x: 27
+    y: -13
+  - x: 25
+    y: -13
+  - x: 25
+    y: -12
+  - x: 26
+    y: -12
+  - x: 27
+    y: -12
+  - x: 28
+    y: -13
+  - x: 28
+    y: -14
+  - x: 24
+    y: -13
+  - x: 24
+    y: -12
+  - x: 24
+    y: -11
+  - x: 25
+    y: -11
+  - x: 26
+    y: -11
+  - x: 27
+    y: -11
+  - x: 28
+    y: -12
+  - x: 24
+    y: -10
+  - x: 25
+    y: -10
+  - x: 26
+    y: -10
+  - x: 27
+    y: -10
+  - x: 28
+    y: -11
+  - x: 24
+    y: -9
+  - x: 25
+    y: -9
+  - x: 26
+    y: -9
+  - x: 26
+    y: -7
+  - x: 27
+    y: -7
+  - x: 27
+    y: -8
+  - x: 26
+    y: -8
+  - x: 25
+    y: -7
+  - x: 25
+    y: -6
+  - x: 26
+    y: -6
+  - x: 27
+    y: -6
+  - x: 28
+    y: -7
+  - x: 28
+    y: -8
+  - x: 28
+    y: -9
+  - x: 27
+    y: -9
+  - x: 25
+    y: -8
+  - x: 24
+    y: -7
+  - x: 24
+    y: -6
+  - x: 24
+    y: -5
+  - x: 25
+    y: -5
+  - x: 26
+    y: -5
+  - x: 27
+    y: -5
+  - x: 28
+    y: -6
+  - x: 24
+    y: -4
+  - x: 25
+    y: -4
+  - x: 26
+    y: -4
+  - x: 27
+    y: -4
+  - x: 28
+    y: -5
+  - x: 24
+    y: -3
+  - x: 25
+    y: -3
+  - x: 26
+    y: -3
+  - x: 27
+    y: -3
+  - x: 25
+    y: -2
+  - x: 26
+    y: -2
+  - x: 27
+    y: -2
+  - x: 28
+    y: -3
+  - x: 28
+    y: -4
+  - x: 24
+    y: -2
+  - x: 24
+    y: -1
+  - x: 25
+    y: -1
+  - x: 26
+    y: -1
+  - x: 28
+    y: -2
+  - x: 29
+    y: -3
+  - x: 29
+    y: -4
+  - x: 29
+    y: -5
+  - x: 27
+    y: -1
+  - x: 29
+    y: -2
+  - x: 30
+    y: -3
+  - x: 30
+    y: -4
+  - x: 30
+    y: -5
+  - x: 28
+    y: -1
+  - x: 31
+    y: -4
+  - x: 31
+    y: -5
+  - x: 31
+    y: -6
+  - x: 30
+    y: -6
+  - x: 29
+    y: -6
+  - x: 32
+    y: -5
+  - x: 32
+    y: -6
+  - x: 32
+    y: -7
+  - x: 31
+    y: -7
+  - x: 30
+    y: -7
+  - x: 32
+    y: -8
+  - x: 31
+    y: -8
+  - x: 30
+    y: -8
+  - x: 29
+    y: -7
+  - x: 32
+    y: -10
+  - x: 33
+    y: -10
+  - x: 33
+    y: -11
+  - x: 32
+    y: -11
+  - x: 31
+    y: -10
+  - x: 31
+    y: -9
+  - x: 32
+    y: -9
+  - x: 33
+    y: -9
+  - x: 34
+    y: -10
+  - x: 34
+    y: -11
+  - x: 34
+    y: -12
+  - x: 33
+    y: -12
+  - x: 32
+    y: -12
+  - x: 31
+    y: -11
+  - x: 30
+    y: -10
+  - x: 30
+    y: -9
+  - x: 34
+    y: -13
+  - x: 33
+    y: -13
+  - x: 32
+    y: -13
+  - x: 31
+    y: -12
+  - x: 30
+    y: -11
+  - x: 35
+    y: -12
+  - x: 35
+    y: -13
+  - x: 35
+    y: -14
+  - x: 34
+    y: -14
+  - x: 33
+    y: -14
+  - x: 35
+    y: -15
+  - x: 34
+    y: -15
+  - x: 33
+    y: -15
+  - x: 32
+    y: -14
+  - x: 31
+    y: -13
+  - x: 35
+    y: -18
+  - x: 36
+    y: -18
+  - x: 36
+    y: -19
+  - x: 35
+    y: -19
+  - x: 34
+    y: -18
+  - x: 34
+    y: -17
+  - x: 35
+    y: -17
+  - x: 36
+    y: -17
+  - x: 37
+    y: -18
+  - x: 37
+    y: -19
+  - x: 37
+    y: -20
+  - x: 36
+    y: -20
+  - x: 35
+    y: -20
+  - x: 34
+    y: -19
+  - x: 33
+    y: -18
+  - x: 33
+    y: -17
+  - x: 33
+    y: -16
+  - x: 34
+    y: -16
+  - x: 35
+    y: -16
+  - x: 38
+    y: -19
+  - x: 38
+    y: -20
+  - x: 38
+    y: -21
+  - x: 37
+    y: -21
+  - x: 36
+    y: -21
+  - x: 37
+    y: -22
+  - x: 38
+    y: -22
+  - x: 38
+    y: -23
+  - x: 37
+    y: -23
+  - x: 36
+    y: -22
+  - x: 39
+    y: -22
+  - x: 39
+    y: -23
+  - x: 39
+    y: -24
+  - x: 38
+    y: -24
+  - x: 37
+    y: -24
+  - x: 36
+    y: -23
+  - x: 35
+    y: -22
+  - x: 35
+    y: -21
+  - x: 40
+    y: -23
+  - x: 40
+    y: -24
+  - x: 40
+    y: -25
+  - x: 39
+    y: -25
+  - x: 38
+    y: -25
+  - x: 40
+    y: -22
+  - x: 39
+    y: -21
+  - x: 40
+    y: -21
+  - x: 41
+    y: -22
+  - x: 41
+    y: -23
+  - x: 41
+    y: -24
+  - x: 39
+    y: -20
+  - x: 41
+    y: -20
+  - x: 42
+    y: -20
+  - x: 42
+    y: -21
+  - x: 41
+    y: -21
+  - x: 40
+    y: -20
+  - x: 40
+    y: -19
+  - x: 41
+    y: -19
+  - x: 42
+    y: -19
+  - x: 43
+    y: -20
+  - x: 43
+    y: -21
+  - x: 43
+    y: -22
+  - x: 42
+    y: -22
+  - x: 39
+    y: -19
+  - x: 39
+    y: -18
+  - x: 40
+    y: -18
+  - x: 41
+    y: -18
+  - x: 42
+    y: -18
+  - x: 43
+    y: -19
+  - x: 39
+    y: -17
+  - x: 40
+    y: -17
+  - x: 41
+    y: -17
+  - x: 42
+    y: -15
+  - x: 43
+    y: -15
+  - x: 43
+    y: -16
+  - x: 42
+    y: -16
+  - x: 41
+    y: -15
+  - x: 41
+    y: -14
+  - x: 42
+    y: -14
+  - x: 43
+    y: -14
+  - x: 44
+    y: -15
+  - x: 44
+    y: -16
+  - x: 44
+    y: -17
+  - x: 43
+    y: -17
+  - x: 42
+    y: -17
+  - x: 41
+    y: -16
+  - x: 40
+    y: -15
+  - x: 40
+    y: -14
+  - x: 40
+    y: -13
+  - x: 41
+    y: -13
+  - x: 42
+    y: -13
+  - x: 43
+    y: -13
+  - x: 44
+    y: -13
+  - x: 44
+    y: -14
+  - x: 42
+    y: -12
+  - x: 43
+    y: -12
+  - x: 44
+    y: -12
+  - x: 45
+    y: -13
+  - x: 45
+    y: -14
+  - x: 45
+    y: -15
+  - x: 41
+    y: -12
+  - x: 41
+    y: -11
+  - x: 42
+    y: -11
+  - x: 43
+    y: -11
+  - x: 40
+    y: -12
+  - x: 40
+    y: -11
+  - x: 40
+    y: -10
+  - x: 41
+    y: -10
+  - x: 42
+    y: -10
+  - x: 43
+    y: -10
+  - x: 44
+    y: -11
+  - x: 40
+    y: -9
+  - x: 41
+    y: -9
+  - x: 42
+    y: -9
+  - x: 57
+    y: -18
+  - x: 58
+    y: -18
+  - x: 58
+    y: -19
+  - x: 57
+    y: -19
+  - x: 56
+    y: -18
+  - x: 56
+    y: -17
+  - x: 57
+    y: -17
+  - x: 58
+    y: -17
+  - x: 59
+    y: -18
+  - x: 59
+    y: -19
+  - x: 59
+    y: -20
+  - x: 58
+    y: -20
+  - x: 57
+    y: -20
+  - x: 56
+    y: -19
+  - x: 55
+    y: -18
+  - x: 55
+    y: -17
+  - x: 55
+    y: -16
+  - x: 56
+    y: -16
+  - x: 57
+    y: -16
+  - x: 56
+    y: -20
+  - x: 55
+    y: -19
+  - x: 54
+    y: -18
+  - x: 54
+    y: -17
+  - x: 54
+    y: -16
+  - x: 55
+    y: -20
+  - x: 56
+    y: -21
+  - x: 55
+    y: -21
+  - x: 54
+    y: -20
+  - x: 54
+    y: -19
+  - x: 57
+    y: -21
+  - x: 57
+    y: -22
+  - x: 56
+    y: -22
+  - x: 55
+    y: -22
+  - x: 54
+    y: -21
+  - x: 53
+    y: -20
+  - x: 53
+    y: -19
+  - x: 53
+    y: -18
+  - x: 57
+    y: -23
+  - x: 56
+    y: -23
+  - x: 55
+    y: -23
+  - x: 54
+    y: -22
+  - x: 53
+    y: -21
+  - x: 53
+    y: -24
+  - x: 54
+    y: -24
+  - x: 54
+    y: -25
+  - x: 53
+    y: -25
+  - x: 52
+    y: -24
+  - x: 52
+    y: -23
+  - x: 53
+    y: -23
+  - x: 54
+    y: -23
+  - x: 55
+    y: -24
+  - x: 55
+    y: -25
+  - x: 55
+    y: -26
+  - x: 54
+    y: -26
+  - x: 53
+    y: -26
+  - x: 52
+    y: -25
+  - x: 51
+    y: -24
+  - x: 51
+    y: -23
+  - x: 51
+    y: -22
+  - x: 52
+    y: -22
+  - x: 53
+    y: -22
+  - x: 52
+    y: -28
+  - x: 53
+    y: -28
+  - x: 53
+    y: -29
+  - x: 52
+    y: -29
+  - x: 51
+    y: -28
+  - x: 51
+    y: -27
+  - x: 52
+    y: -27
+  - x: 53
+    y: -27
+  - x: 54
+    y: -28
+  - x: 54
+    y: -29
+  - x: 54
+    y: -30
+  - x: 53
+    y: -30
+  - x: 52
+    y: -30
+  - x: 51
+    y: -29
+  - x: 50
+    y: -28
+  - x: 50
+    y: -27
+  - x: 50
+    y: -26
+  - x: 51
+    y: -26
+  - x: 52
+    y: -26
+  - x: 51
+    y: -30
+  - x: 52
+    y: -31
+  - x: 51
+    y: -31
+  - x: 50
+    y: -30
+  - x: 50
+    y: -29
+  - x: 53
+    y: -31
+  - x: 53
+    y: -32
+  - x: 52
+    y: -32
+  - x: 51
+    y: -32
+  - x: 50
+    y: -31
+  - x: 49
+    y: -30
+  - x: 49
+    y: -29
+  - x: 49
+    y: -28
+  - x: 53
+    y: -33
+  - x: 52
+    y: -33
+  - x: 51
+    y: -33
+  - x: 50
+    y: -32
+  - x: 49
+    y: -31
+  - x: 54
+    y: -31
+  - x: 54
+    y: -32
+  - x: 54
+    y: -33
+  - x: 54
+    y: -27
+  - x: 55
+    y: -27
+  - x: 55
+    y: -28
+  - x: 51
+    y: -25
+  - x: 56
+    y: -24
+  - x: 56
+    y: -25
+  - x: 57
+    y: -24
+  - x: 57
+    y: -25
+  - x: 57
+    y: -26
+  - x: 56
+    y: -26
+  - x: 58
+    y: -24
+  - x: 58
+    y: -25
+  - x: 58
+    y: -26
+  - x: 60
+    y: -24
+  - x: 61
+    y: -24
+  - x: 61
+    y: -25
+  - x: 60
+    y: -25
+  - x: 59
+    y: -24
+  - x: 59
+    y: -23
+  - x: 60
+    y: -23
+  - x: 61
+    y: -23
+  - x: 62
+    y: -24
+  - x: 62
+    y: -25
+  - x: 62
+    y: -26
+  - x: 61
+    y: -26
+  - x: 60
+    y: -26
+  - x: 59
+    y: -25
+  - x: 58
+    y: -23
+  - x: 58
+    y: -22
+  - x: 59
+    y: -22
+  - x: 60
+    y: -22
+  - x: 63
+    y: -25
+  - x: 63
+    y: -26
+  - x: 63
+    y: -27
+  - x: 62
+    y: -27
+  - x: 61
+    y: -27
+  - x: 65
+    y: -26
+  - x: 66
+    y: -26
+  - x: 66
+    y: -27
+  - x: 65
+    y: -27
+  - x: 64
+    y: -26
+  - x: 64
+    y: -25
+  - x: 65
+    y: -25
+  - x: 66
+    y: -25
+  - x: 67
+    y: -26
+  - x: 67
+    y: -27
+  - x: 67
+    y: -28
+  - x: 66
+    y: -28
+  - x: 65
+    y: -28
+  - x: 64
+    y: -27
+  - x: 63
+    y: -24
+  - x: 64
+    y: -24
+  - x: 65
+    y: -24
+  - x: 64
+    y: -28
+  - x: 60
+    y: -27
+  - x: 59
+    y: -26
+  - x: 58
+    y: -27
+  - x: 57
+    y: -27
+  - x: 56
+    y: -27
+  - x: 57
+    y: -28
+  - x: 56
+    y: -28
+  - x: 58
+    y: -28
+  - x: 58
+    y: -29
+  - x: 57
+    y: -29
+  - x: 56
+    y: -29
+  - x: 59
+    y: -31
+  - x: 60
+    y: -31
+  - x: 60
+    y: -32
+  - x: 59
+    y: -32
+  - x: 58
+    y: -31
+  - x: 58
+    y: -30
+  - x: 59
+    y: -30
+  - x: 60
+    y: -30
+  - x: 61
+    y: -31
+  - x: 61
+    y: -32
+  - x: 61
+    y: -33
+  - x: 60
+    y: -33
+  - x: 59
+    y: -33
+  - x: 58
+    y: -32
+  - x: 57
+    y: -31
+  - x: 57
+    y: -30
+  - x: 59
+    y: -29
+  - x: 61
+    y: -35
+  - x: 62
+    y: -35
+  - x: 62
+    y: -36
+  - x: 61
+    y: -36
+  - x: 60
+    y: -35
+  - x: 60
+    y: -34
+  - x: 61
+    y: -34
+  - x: 62
+    y: -34
+  - x: 63
+    y: -35
+  - x: 63
+    y: -36
+  - x: 63
+    y: -37
+  - x: 62
+    y: -37
+  - x: 61
+    y: -37
+  - x: 60
+    y: -36
+  - x: 59
+    y: -35
+  - x: 59
+    y: -34
+  - x: 84
+    y: -38
+  - x: 85
+    y: -38
+  - x: 85
+    y: -39
+  - x: 84
+    y: -39
+  - x: 83
+    y: -38
+  - x: 83
+    y: -37
+  - x: 84
+    y: -37
+  - x: 82
+    y: -37
+  - x: 82
+    y: -36
+  - x: 83
+    y: -36
+  - x: 80
+    y: -35
+  - x: 81
+    y: -35
+  - x: 81
+    y: -36
+  - x: 80
+    y: -36
+  - x: 79
+    y: -35
+  - x: 79
+    y: -34
+  - x: 80
+    y: -34
+  - x: 76
+    y: -34
+  - x: 77
+    y: -34
+  - x: 77
+    y: -35
+  - x: 76
+    y: -35
+  - x: 75
+    y: -34
+  - x: 75
+    y: -33
+  - x: 76
+    y: -33
+  - x: 74
+    y: -35
+  - x: 75
+    y: -35
+  - x: 75
+    y: -36
+  - x: 74
+    y: -36
+  - x: 73
+    y: -35
+  - x: 73
+    y: -34
+  - x: 74
+    y: -34
+  - x: 75
+    y: -37
+  - x: 74
+    y: -37
+  - x: 73
+    y: -36
+  - x: 76
+    y: -39
+  - x: 77
+    y: -39
+  - x: 77
+    y: -40
+  - x: 76
+    y: -40
+  - x: 75
+    y: -39
+  - x: 75
+    y: -38
+  - x: 76
+    y: -38
+  - x: 79
+    y: -43
+  - x: 80
+    y: -43
+  - x: 80
+    y: -44
+  - x: 79
+    y: -44
+  - x: 78
+    y: -43
+  - x: 78
+    y: -42
+  - x: 79
+    y: -42
+  - x: 80
+    y: -45
+  - x: 81
+    y: -45
+  - x: 81
+    y: -46
+  - x: 80
+    y: -46
+  - x: 79
+    y: -45
+  - x: 81
+    y: -47
+  - x: 80
+    y: -47
+  - x: 79
+    y: -46
+  - x: 80
+    y: -48
+  - x: 81
+    y: -48
+  - x: 81
+    y: -49
+  - x: 80
+    y: -49
+  - x: 79
+    y: -48
+  - x: 79
+    y: -47
+  - x: 79
+    y: -49
+  - x: 78
+    y: -48
+  - x: 78
+    y: -47
+  - x: 78
+    y: -49
+  - x: 77
+    y: -48
+  - x: 77
+    y: -47
+  - x: 76
+    y: -48
+  - x: 77
+    y: -49
+  - x: 76
+    y: -49
+  - x: 75
+    y: -48
+  - x: 75
+    y: -47
+  - x: 76
+    y: -47
+  - x: 73
+    y: -46
+  - x: 74
+    y: -46
+  - x: 74
+    y: -47
+  - x: 73
+    y: -47
+  - x: 72
+    y: -46
+  - x: 72
+    y: -45
+  - x: 73
+    y: -45
+  - x: 71
+    y: -45
+  - x: 71
+    y: -46
+  - x: 70
+    y: -45
+  - x: 70
+    y: -44
+  - x: 71
+    y: -44
+  SecondArray: []
+--- !u!4 &339123589
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 339123587}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.6854458, y: 1.2332773, z: -0.17784977}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &369789276
 GameObject:
   m_ObjectHideFlags: 0
@@ -538,8 +2333,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9c928ea15ae74a44089beb2e534c1a35, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  layerName: Default
-  layerIndex: 4
 --- !u!1 &732714203
 GameObject:
   m_ObjectHideFlags: 0
@@ -1355,6 +3148,10 @@ MonoBehaviour:
     int1: 0
     nest2:
       int2: 0
+  inheritedNest:
+    int1: 0
+    nest2:
+      int2: 0
 --- !u!1 &1524906390
 GameObject:
   m_ObjectHideFlags: 0
@@ -1402,23 +3199,32 @@ MonoBehaviour:
   show1: 0
   show2: 0
   enum1: 0
+  enum2: 0
   showIfAll: 
   showIfAny: 
   showIfEnum: 
+  showIfEnumFlag: 
+  showIfEnumFlagMulti: 
   nest1:
     show1: 1
     show2: 0
     enum1: 0
+    enum2: 0
     showIfAll: 0
     showIfAny: 0
     showIfEnum: 0
+    showIfEnumFlag: 0
+    showIfEnumFlagMulti: 0
     nest2:
       show1: 1
       show2: 1
       enum1: 0
+      enum2: 0
       showIfAll: {x: 0.25, y: 0.75}
       showIfAny: {x: 0.25, y: 0.75}
       showIfEnum: {x: 0.25, y: 0.75}
+      showIfEnumFlag: {x: 0, y: 0}
+      showIfEnumFlagMulti: {x: 0, y: 0}
 --- !u!114 &1524906393
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1434,23 +3240,32 @@ MonoBehaviour:
   hide1: 0
   hide2: 0
   enum1: 0
+  enum2: 0
   hideIfAll: 
   hideIfAny: 
   hideIfEnum: 
+  hideIfEnumFlag: 
+  hideIfEnumFlagMulti: 
   nest1:
     hide1: 1
     hide2: 0
     enum1: 0
+    enum2: 0
     hideIfAll: 0
     hideIfAny: 0
     hideIfEnum: 0
+    hideIfEnumFlag: 0
+    hideIfEnumFlagMulti: 0
     nest2:
       hide1: 1
       hide2: 1
       enum1: 0
+      enum2: 0
       hideIfAll: {x: 0.25, y: 0.75}
       hideIfAny: {x: 0.25, y: 0.75}
       hideIfEnum: {x: 0.25, y: 0.75}
+      hideIfEnumFlag: {x: 0, y: 0}
+      hideIfEnumFlagMulti: {x: 0, y: 0}
 --- !u!1 &1552114399
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/NaughtyAttributes/Samples/DemoScene/DemoScene.unity.meta
+++ b/Assets/NaughtyAttributes/Samples/DemoScene/DemoScene.unity.meta
@@ -1,7 +1,7 @@
 fileFormatVersion: 2
 guid: 07845a5477be2b149a6f1cb32b5a3a5b
 timeCreated: 1507998788
-licenseType: Free
+licenseType: Store
 DefaultImporter:
   externalObjects: {}
   userData: 

--- a/Assets/NaughtyAttributes/Samples/DemoScene/TestAssets.meta
+++ b/Assets/NaughtyAttributes/Samples/DemoScene/TestAssets.meta
@@ -2,7 +2,7 @@ fileFormatVersion: 2
 guid: 53a462744f22ca549927c5e6ea797362
 folderAsset: yes
 timeCreated: 1509089305
-licenseType: Free
+licenseType: Store
 DefaultImporter:
   externalObjects: {}
   userData: 

--- a/Assets/NaughtyAttributes/Samples/DemoScene/TestAssets/Cube.prefab.meta
+++ b/Assets/NaughtyAttributes/Samples/DemoScene/TestAssets/Cube.prefab.meta
@@ -1,7 +1,7 @@
 fileFormatVersion: 2
 guid: 7ec354ef3daae7641b7a3fa5e1fe0c81
 timeCreated: 1509089337
-licenseType: Free
+licenseType: Store
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 100100000

--- a/Assets/NaughtyAttributes/Samples/DemoScene/TestAssets/NaughtyScriptableObject.asset.meta
+++ b/Assets/NaughtyAttributes/Samples/DemoScene/TestAssets/NaughtyScriptableObject.asset.meta
@@ -1,7 +1,7 @@
 fileFormatVersion: 2
 guid: 9cf80899b80517945a2d2390fb48877f
 timeCreated: 1518639643
-licenseType: Free
+licenseType: Store
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000

--- a/Assets/NaughtyAttributes/Samples/DemoScene/TestAssets/TestScriptableObjectB.asset
+++ b/Assets/NaughtyAttributes/Samples/DemoScene/TestAssets/TestScriptableObjectB.asset
@@ -12,4 +12,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c2b396aeebc9d984da298eee313896bc, type: 3}
   m_Name: TestScriptableObjectB
   m_EditorClassIdentifier: 
-  slider: {x: 3, y: 7}
+  slider: {x: 4, y: 8}

--- a/Assets/NaughtyAttributes/Scripts.meta
+++ b/Assets/NaughtyAttributes/Scripts.meta
@@ -2,7 +2,7 @@ fileFormatVersion: 2
 guid: 66686847ee1fa044bb15dfe473666178
 folderAsset: yes
 timeCreated: 1507995546
-licenseType: Free
+licenseType: Store
 DefaultImporter:
   externalObjects: {}
   userData: 

--- a/Assets/NaughtyAttributes/Scripts/Core.meta
+++ b/Assets/NaughtyAttributes/Scripts/Core.meta
@@ -2,7 +2,7 @@ fileFormatVersion: 2
 guid: 1f67e408a6d0adf4ab29d095ccd8b116
 folderAsset: yes
 timeCreated: 1507998942
-licenseType: Free
+licenseType: Store
 DefaultImporter:
   externalObjects: {}
   userData: 

--- a/Assets/NaughtyAttributes/Scripts/Core/DrawerAttributes_SpecialCase/HexBrushAttribute.cs
+++ b/Assets/NaughtyAttributes/Scripts/Core/DrawerAttributes_SpecialCase/HexBrushAttribute.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using UnityEngine;
+
+namespace NaughtyAttributes {
+	[AttributeUsage(AttributeTargets.Field, AllowMultiple = false, Inherited = true)]
+	public class HexBrushAttribute : SpecialCaseDrawerAttribute {
+		public enum HexBrush { Additive, Main }
+		public HexBrush brushType;
+
+		public HexBrushAttribute(HexBrush type = HexBrush.Main) {
+			brushType = type;
+		}
+
+	}
+}

--- a/Assets/NaughtyAttributes/Scripts/Core/DrawerAttributes_SpecialCase/HexBrushAttribute.cs.meta
+++ b/Assets/NaughtyAttributes/Scripts/Core/DrawerAttributes_SpecialCase/HexBrushAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 793698a1d9a1c4e46b3e4214beac06cd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/NaughtyAttributes/Scripts/Core/DrawerAttributes_SpecialCase/SpecialCaseDrawerAttribute.cs
+++ b/Assets/NaughtyAttributes/Scripts/Core/DrawerAttributes_SpecialCase/SpecialCaseDrawerAttribute.cs
@@ -2,7 +2,7 @@
 
 namespace NaughtyAttributes
 {
-	public class SpecialCaseDrawerAttribute : Attribute, INaughtyAttribute
-	{
+	public class SpecialCaseDrawerAttribute : Attribute, INaughtyAttribute {
+		
 	}
 }

--- a/Assets/NaughtyAttributes/Scripts/Core/NaughtyAttributes.Core.asmdef
+++ b/Assets/NaughtyAttributes/Scripts/Core/NaughtyAttributes.Core.asmdef
@@ -1,6 +1,10 @@
 {
     "name": "NaughtyAttributes.Core",
-    "references": [],
+    "rootNamespace": "",
+    "references": [
+        "GUID:60fd1960cd0079a4cb0401a37c2db3d4",
+        "GUID:825fd54a1be4dd7448e37859df8d2eb3"
+    ],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
@@ -8,5 +12,6 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": []
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/Assets/NaughtyAttributes/Scripts/Editor.meta
+++ b/Assets/NaughtyAttributes/Scripts/Editor.meta
@@ -2,7 +2,7 @@ fileFormatVersion: 2
 guid: b76068e69df25a94ab378b0b6829c4f0
 folderAsset: yes
 timeCreated: 1507995613
-licenseType: Free
+licenseType: Store
 DefaultImporter:
   externalObjects: {}
   userData: 

--- a/Assets/NaughtyAttributes/Scripts/Editor/NaughtyAttributes.Editor.asmdef
+++ b/Assets/NaughtyAttributes/Scripts/Editor/NaughtyAttributes.Editor.asmdef
@@ -1,9 +1,11 @@
 {
     "name": "NaughtyAttributes.Editor",
+    "rootNamespace": "",
     "references": [
-        "NaughtyAttributes.Core"
+        "GUID:776d03a35f1b52c4a9aed9f56d7b4229",
+        "GUID:60fd1960cd0079a4cb0401a37c2db3d4",
+        "GUID:825fd54a1be4dd7448e37859df8d2eb3"
     ],
-    "optionalUnityReferences": [],
     "includePlatforms": [
         "Editor"
     ],
@@ -12,5 +14,7 @@
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": []
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/Assets/NaughtyAttributes/Scripts/Editor/NaughtyInspector.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/NaughtyInspector.cs
@@ -4,20 +4,17 @@ using System.Reflection;
 using UnityEditor;
 using UnityEngine;
 
-namespace NaughtyAttributes.Editor
-{
+namespace NaughtyAttributes.Editor {
 	[CanEditMultipleObjects]
 	[CustomEditor(typeof(UnityEngine.Object), true)]
-	public class NaughtyInspector : UnityEditor.Editor
-	{
+	public class NaughtyInspector : UnityEditor.Editor {
 		private List<SerializedProperty> _serializedProperties = new List<SerializedProperty>();
 		private IEnumerable<FieldInfo> _nonSerializedFields;
 		private IEnumerable<PropertyInfo> _nativeProperties;
 		private IEnumerable<MethodInfo> _methods;
 		private Dictionary<string, SavedBool> _foldouts = new Dictionary<string, SavedBool>();
 
-		protected virtual void OnEnable()
-		{
+		protected virtual void OnEnable() {
 			_nonSerializedFields = ReflectionUtility.GetAllFields(
 				target, f => f.GetCustomAttributes(typeof(ShowNonSerializedFieldAttribute), true).Length > 0);
 
@@ -26,24 +23,37 @@ namespace NaughtyAttributes.Editor
 
 			_methods = ReflectionUtility.GetAllMethods(
 				target, m => m.GetCustomAttributes(typeof(ButtonAttribute), true).Length > 0);
+
+			GetSerializedProperties(ref _serializedProperties);
+			foreach(SerializedProperty prop in _serializedProperties) {
+
+				SpecialCaseDrawerAttribute specialCaseAttribute = PropertyUtility.GetAttribute<SpecialCaseDrawerAttribute>(prop);
+				if(specialCaseAttribute != null) {
+					specialCaseAttribute.GetDrawer(prop).Enable(specialCaseAttribute, prop);
+				}
+			}
 		}
 
-		protected virtual void OnDisable()
-		{
+		protected virtual void OnDisable() {
+			foreach(SerializedProperty prop in _serializedProperties) {
+
+				SpecialCaseDrawerAttribute specialCaseAttribute = PropertyUtility.GetAttribute<SpecialCaseDrawerAttribute>(prop);
+				if(specialCaseAttribute != null) {
+					specialCaseAttribute.GetDrawer(prop).Disable();
+				}
+			}
+
 			ReorderableListPropertyDrawer.Instance.ClearCache();
+			MultipleSpecialDrawer.Instances.Clear();
 		}
 
-		public override void OnInspectorGUI()
-		{
+		public override void OnInspectorGUI() {
 			GetSerializedProperties(ref _serializedProperties);
 
 			bool anyNaughtyAttribute = _serializedProperties.Any(p => PropertyUtility.GetAttribute<INaughtyAttribute>(p) != null);
-			if (!anyNaughtyAttribute)
-			{
+			if(!anyNaughtyAttribute) {
 				DrawDefaultInspector();
-			}
-			else
-			{
+			} else {
 				DrawSerializedProperties();
 			}
 
@@ -52,54 +62,41 @@ namespace NaughtyAttributes.Editor
 			DrawButtons();
 		}
 
-		protected void GetSerializedProperties(ref List<SerializedProperty> outSerializedProperties)
-		{
+		protected void GetSerializedProperties(ref List<SerializedProperty> outSerializedProperties) {
 			outSerializedProperties.Clear();
-			using (var iterator = serializedObject.GetIterator())
-			{
-				if (iterator.NextVisible(true))
-				{
-					do
-					{
+			using(var iterator = serializedObject.GetIterator()) {
+				if(iterator.NextVisible(true)) {
+					do {
 						outSerializedProperties.Add(serializedObject.FindProperty(iterator.name));
 					}
-					while (iterator.NextVisible(false));
+					while(iterator.NextVisible(false));
 				}
 			}
 		}
 
-		protected void DrawSerializedProperties()
-		{
+		protected void DrawSerializedProperties() {
 			serializedObject.Update();
 
 			// Draw non-grouped serialized properties
-			foreach (var property in GetNonGroupedProperties(_serializedProperties))
-			{
-				if (property.name.Equals("m_Script", System.StringComparison.Ordinal))
-				{
-					using (new EditorGUI.DisabledScope(disabled: true))
-					{
+			foreach(var property in GetNonGroupedProperties(_serializedProperties)) {
+				if(property.name.Equals("m_Script", System.StringComparison.Ordinal)) {
+					using(new EditorGUI.DisabledScope(disabled: true)) {
 						EditorGUILayout.PropertyField(property);
 					}
-				}
-				else
-				{
+				} else {
 					NaughtyEditorGUI.PropertyField_Layout(property, includeChildren: true);
 				}
 			}
 
 			// Draw grouped serialized properties
-			foreach (var group in GetGroupedProperties(_serializedProperties))
-			{
+			foreach(var group in GetGroupedProperties(_serializedProperties)) {
 				IEnumerable<SerializedProperty> visibleProperties = group.Where(p => PropertyUtility.IsVisible(p));
-				if (!visibleProperties.Any())
-				{
+				if(!visibleProperties.Any()) {
 					continue;
 				}
 
 				NaughtyEditorGUI.BeginBoxGroup_Layout(group.Key);
-				foreach (var property in visibleProperties)
-				{
+				foreach(var property in visibleProperties) {
 					NaughtyEditorGUI.PropertyField_Layout(property, includeChildren: true);
 				}
 
@@ -107,24 +104,19 @@ namespace NaughtyAttributes.Editor
 			}
 
 			// Draw foldout serialized properties
-			foreach (var group in GetFoldoutProperties(_serializedProperties))
-			{
+			foreach(var group in GetFoldoutProperties(_serializedProperties)) {
 				IEnumerable<SerializedProperty> visibleProperties = group.Where(p => PropertyUtility.IsVisible(p));
-				if (!visibleProperties.Any())
-				{
+				if(!visibleProperties.Any()) {
 					continue;
 				}
 
-				if (!_foldouts.ContainsKey(group.Key))
-				{
+				if(!_foldouts.ContainsKey(group.Key)) {
 					_foldouts[group.Key] = new SavedBool($"{target.GetInstanceID()}.{group.Key}", false);
 				}
 
 				_foldouts[group.Key].Value = EditorGUILayout.Foldout(_foldouts[group.Key].Value, group.Key, true);
-				if (_foldouts[group.Key].Value)
-				{
-					foreach (var property in visibleProperties)
-					{
+				if(_foldouts[group.Key].Value) {
+					foreach(var property in visibleProperties) {
 						NaughtyEditorGUI.PropertyField_Layout(property, true);
 					}
 				}
@@ -133,84 +125,68 @@ namespace NaughtyAttributes.Editor
 			serializedObject.ApplyModifiedProperties();
 		}
 
-		protected void DrawNonSerializedFields(bool drawHeader = false)
-		{
-			if (_nonSerializedFields.Any())
-			{
-				if (drawHeader)
-				{
+		protected void DrawNonSerializedFields(bool drawHeader = false) {
+			if(_nonSerializedFields.Any()) {
+				if(drawHeader) {
 					EditorGUILayout.Space();
 					EditorGUILayout.LabelField("Non-Serialized Fields", GetHeaderGUIStyle());
 					NaughtyEditorGUI.HorizontalLine(
 						EditorGUILayout.GetControlRect(false), HorizontalLineAttribute.DefaultHeight, HorizontalLineAttribute.DefaultColor.GetColor());
 				}
 
-				foreach (var field in _nonSerializedFields)
-				{
+				foreach(var field in _nonSerializedFields) {
 					NaughtyEditorGUI.NonSerializedField_Layout(serializedObject.targetObject, field);
 				}
 			}
 		}
 
-		protected void DrawNativeProperties(bool drawHeader = false)
-		{
-			if (_nativeProperties.Any())
-			{
-				if (drawHeader)
-				{
+		protected void DrawNativeProperties(bool drawHeader = false) {
+			if(_nativeProperties.Any()) {
+				if(drawHeader) {
 					EditorGUILayout.Space();
 					EditorGUILayout.LabelField("Native Properties", GetHeaderGUIStyle());
 					NaughtyEditorGUI.HorizontalLine(
 						EditorGUILayout.GetControlRect(false), HorizontalLineAttribute.DefaultHeight, HorizontalLineAttribute.DefaultColor.GetColor());
 				}
 
-				foreach (var property in _nativeProperties)
-				{
+				foreach(var property in _nativeProperties) {
 					NaughtyEditorGUI.NativeProperty_Layout(serializedObject.targetObject, property);
 				}
 			}
 		}
 
-		protected void DrawButtons(bool drawHeader = false)
-		{
-			if (_methods.Any())
-			{
-				if (drawHeader)
-				{
+		protected void DrawButtons(bool drawHeader = false) {
+			if(_methods.Any()) {
+				if(drawHeader) {
 					EditorGUILayout.Space();
 					EditorGUILayout.LabelField("Buttons", GetHeaderGUIStyle());
 					NaughtyEditorGUI.HorizontalLine(
 						EditorGUILayout.GetControlRect(false), HorizontalLineAttribute.DefaultHeight, HorizontalLineAttribute.DefaultColor.GetColor());
 				}
 
-				foreach (var method in _methods)
-				{
+				foreach(var method in _methods) {
 					NaughtyEditorGUI.Button(serializedObject.targetObject, method);
 				}
 			}
 		}
 
-		private static IEnumerable<SerializedProperty> GetNonGroupedProperties(IEnumerable<SerializedProperty> properties)
-		{
+		private static IEnumerable<SerializedProperty> GetNonGroupedProperties(IEnumerable<SerializedProperty> properties) {
 			return properties.Where(p => PropertyUtility.GetAttribute<IGroupAttribute>(p) == null);
 		}
 
-		private static IEnumerable<IGrouping<string, SerializedProperty>> GetGroupedProperties(IEnumerable<SerializedProperty> properties)
-		{
+		private static IEnumerable<IGrouping<string, SerializedProperty>> GetGroupedProperties(IEnumerable<SerializedProperty> properties) {
 			return properties
 				.Where(p => PropertyUtility.GetAttribute<BoxGroupAttribute>(p) != null)
 				.GroupBy(p => PropertyUtility.GetAttribute<BoxGroupAttribute>(p).Name);
 		}
 
-		private static IEnumerable<IGrouping<string, SerializedProperty>> GetFoldoutProperties(IEnumerable<SerializedProperty> properties)
-		{
+		private static IEnumerable<IGrouping<string, SerializedProperty>> GetFoldoutProperties(IEnumerable<SerializedProperty> properties) {
 			return properties
 				.Where(p => PropertyUtility.GetAttribute<FoldoutAttribute>(p) != null)
 				.GroupBy(p => PropertyUtility.GetAttribute<FoldoutAttribute>(p).Name);
 		}
 
-		private static GUIStyle GetHeaderGUIStyle()
-		{
+		private static GUIStyle GetHeaderGUIStyle() {
 			GUIStyle style = new GUIStyle(EditorStyles.centeredGreyMiniLabel);
 			style.fontStyle = FontStyle.Bold;
 			style.alignment = TextAnchor.UpperCenter;

--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/PropertyDrawerBase.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/PropertyDrawerBase.cs
@@ -1,23 +1,18 @@
 ﻿using UnityEditor;
 using UnityEngine;
 
-namespace NaughtyAttributes.Editor
-{
-	public abstract class PropertyDrawerBase : PropertyDrawer
-	{
-		public sealed override void OnGUI(Rect rect, SerializedProperty property, GUIContent label)
-		{
+namespace NaughtyAttributes.Editor {
+	public abstract class PropertyDrawerBase : PropertyDrawer {
+		public sealed override void OnGUI(Rect rect, SerializedProperty property, GUIContent label) {
 			// Check if visible
 			bool visible = PropertyUtility.IsVisible(property);
-			if (!visible)
-			{
+			if(!visible) {
 				return;
 			}
 
 			// Validate
 			ValidatorAttribute[] validatorAttributes = PropertyUtility.GetAttributes<ValidatorAttribute>(property);
-			foreach (var validatorAttribute in validatorAttributes)
-			{
+			foreach(var validatorAttribute in validatorAttributes) {
 				validatorAttribute.GetValidator().ValidateProperty(property);
 			}
 
@@ -25,54 +20,45 @@ namespace NaughtyAttributes.Editor
 			EditorGUI.BeginChangeCheck();
 			bool enabled = PropertyUtility.IsEnabled(property);
 
-			using (new EditorGUI.DisabledScope(disabled: !enabled))
-			{
+			using(new EditorGUI.DisabledScope(disabled: !enabled)) {
 				OnGUI_Internal(rect, property, PropertyUtility.GetLabel(property));
 			}
 
 			// Call OnValueChanged callbacks
-			if (EditorGUI.EndChangeCheck())
-			{
+			if(EditorGUI.EndChangeCheck()) {
 				PropertyUtility.CallOnValueChangedCallbacks(property);
 			}
 		}
 
 		protected abstract void OnGUI_Internal(Rect rect, SerializedProperty property, GUIContent label);
 
-		sealed override public float GetPropertyHeight(SerializedProperty property, GUIContent label)
-		{
+		sealed override public float GetPropertyHeight(SerializedProperty property, GUIContent label) {
 			bool visible = PropertyUtility.IsVisible(property);
-			if (!visible)
-			{
+			if(!visible) {
 				return 0.0f;
 			}
 
 			return GetPropertyHeight_Internal(property, label);
 		}
 
-		protected virtual float GetPropertyHeight_Internal(SerializedProperty property, GUIContent label)
-		{
+		protected virtual float GetPropertyHeight_Internal(SerializedProperty property, GUIContent label) {
 			return EditorGUI.GetPropertyHeight(property, includeChildren: true);
 		}
 
-		protected float GetPropertyHeight(SerializedProperty property)
-		{
+		protected float GetPropertyHeight(SerializedProperty property) {
 			SpecialCaseDrawerAttribute specialCaseAttribute = PropertyUtility.GetAttribute<SpecialCaseDrawerAttribute>(property);
-			if (specialCaseAttribute != null)
-			{
-				return specialCaseAttribute.GetDrawer().GetPropertyHeight(property);
+			if(specialCaseAttribute != null) {
+				return specialCaseAttribute.GetDrawer(property).GetPropertyHeight(property);
 			}
 
 			return EditorGUI.GetPropertyHeight(property, includeChildren: true);
 		}
 
-		public virtual float GetHelpBoxHeight()
-		{
+		public virtual float GetHelpBoxHeight() {
 			return EditorGUIUtility.singleLineHeight * 2.0f;
 		}
 
-		public void DrawDefaultPropertyAndHelpBox(Rect rect, SerializedProperty property, string message, MessageType messageType)
-		{
+		public void DrawDefaultPropertyAndHelpBox(Rect rect, SerializedProperty property, string message, MessageType messageType) {
 			float indentLength = NaughtyEditorGUI.GetIndentLength(rect);
 			Rect helpBoxRect = new Rect(
 				rect.x + indentLength,

--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers_SpecialCase/HexBrushPropertyDrawer.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers_SpecialCase/HexBrushPropertyDrawer.cs
@@ -1,0 +1,70 @@
+﻿using UnityEngine;
+using UnityEditor;
+using UnityEditorInternal;
+using System.Collections.Generic;
+using NaughtyAttributes;
+
+using NaughtyAttributes.Editor;
+using LoneTower.EditorUtilis;
+using LoneTower.HexSystem;
+
+public class HexBrushPropertyDrawer : MultipleSpecialDrawer {
+
+	HexBrushLogic brush;
+	SerializedProperty prop;
+
+	public HexBrushPropertyDrawer(SerializedProperty prop, SpecialCaseDrawerAttribute attr) : base(prop, attr) {
+	}
+
+	protected override float GetPropertyHeight_Internal(SerializedProperty property) {
+		return EditorGUI.GetPropertyHeight(property, true);
+	}
+
+	protected override void OnGUI_Internal(Rect rect, SerializedProperty property, GUIContent label, SpecialCaseDrawerAttribute specialCaseAttribute) {
+		prop = property;
+
+		if(!(property.isArray && property.type == "HexVector")) {
+			string message = typeof(HexBrushAttribute).Name + " can be used only on arrays or lists";
+			NaughtyEditorGUI.HelpBox_Layout(message, MessageType.Warning, context: property.serializedObject.targetObject);
+			EditorGUILayout.PropertyField(property, true);
+			return;
+		}
+		HexBrushGUIDrawer.Draw(property.name, brush);
+	}
+
+	public override void Disable() {
+		base.Disable();
+		Serialize();
+		brush?.Clear();
+		brush = null;
+	}
+
+	public override void Enable(SpecialCaseDrawerAttribute specialCaseAttribute, SerializedProperty prop) {
+		base.Enable(specialCaseAttribute, prop);
+		HexBrushAttribute.HexBrush t = (specialCaseAttribute as HexBrushAttribute).brushType;
+		HexVector[] v = new HexVector[prop.arraySize];
+
+		for(int i = 0; i < v.Length; i++) {
+			SerializedProperty x = prop.GetArrayElementAtIndex(i).FindPropertyRelative("x");
+			SerializedProperty y = prop.GetArrayElementAtIndex(i).FindPropertyRelative("y");
+			v[i] = new HexVector(x.intValue, y.intValue);
+		}
+
+		switch(t) {
+			case HexBrushAttribute.HexBrush.Additive:
+				brush = new HexBrushAdditive(new List<HexVector>(v), new BrushSettings(1, 1));
+				break;
+			case HexBrushAttribute.HexBrush.Main:
+				brush = new HexBrushMain(new List<HexVector>(v), new BrushSettings(1, 1));
+				break;
+		}
+
+	}
+
+	void Serialize() {
+		HexArraySerializer.Serialize(prop, brush.selection);
+		brush.Clear();
+	}
+
+}
+

--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers_SpecialCase/HexBrushPropertyDrawer.cs.meta
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers_SpecialCase/HexBrushPropertyDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 26a9a258165d33842808fa4491b02041
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers_SpecialCase/MultipleSpecialDrawer.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers_SpecialCase/MultipleSpecialDrawer.cs
@@ -1,0 +1,44 @@
+using NaughtyAttributes;
+using NaughtyAttributes.Editor;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+public class MultipleSpecialDrawer : SpecialCasePropertyDrawerBase {
+
+	public static Dictionary<Tuple<SerializedObject, string>, MultipleSpecialDrawer> Instances = new Dictionary<Tuple<SerializedObject, string>, MultipleSpecialDrawer>();
+
+	SpecialCaseDrawerAttribute attr;
+	SerializedProperty prop;
+
+	public static bool Exists(SerializedProperty prop) {
+		return Instances.ContainsKey(new Tuple<SerializedObject, string>(prop.serializedObject, prop.name));
+	}
+	public static MultipleSpecialDrawer GetDrawer(SerializedProperty prop) {
+		return Instances[new Tuple<SerializedObject, string>(prop.serializedObject, prop.name)];
+	}
+
+
+	public MultipleSpecialDrawer(SerializedProperty prop, SpecialCaseDrawerAttribute attr) {
+		this.prop = prop;
+		this.attr = attr;
+
+		Instances.Add(new Tuple<SerializedObject, string>(prop.serializedObject, prop.name), this);
+	}
+
+	protected override void OnGUI_Internal(Rect rect, SerializedProperty property, GUIContent label, SpecialCaseDrawerAttribute specialCaseAttribute) {
+
+	}
+
+
+	public override void Disable() {
+		base.Disable();
+		Instances.Remove(new Tuple<SerializedObject, string>(prop.serializedObject, prop.name));
+	}
+
+	protected override float GetPropertyHeight_Internal(SerializedProperty property) {
+		return 0;
+	}
+}

--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers_SpecialCase/MultipleSpecialDrawer.cs.meta
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers_SpecialCase/MultipleSpecialDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d0f4e3ce379dfcd48b7997ff8fea5368
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers_SpecialCase/ReorderableListPropertyDrawer.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers_SpecialCase/ReorderableListPropertyDrawer.cs
@@ -3,20 +3,16 @@ using UnityEditor;
 using UnityEditorInternal;
 using System.Collections.Generic;
 
-namespace NaughtyAttributes.Editor
-{
-	public class ReorderableListPropertyDrawer : SpecialCasePropertyDrawerBase
-	{
+namespace NaughtyAttributes.Editor {
+	public class ReorderableListPropertyDrawer : SpecialCasePropertyDrawerBase {
 		public static readonly ReorderableListPropertyDrawer Instance = new ReorderableListPropertyDrawer();
 
 		private readonly Dictionary<string, ReorderableList> _reorderableListsByPropertyName = new Dictionary<string, ReorderableList>();
 
 		private GUIStyle _labelStyle;
 
-		private GUIStyle GetLabelStyle()
-		{
-			if (_labelStyle == null)
-			{
+		private GUIStyle GetLabelStyle() {
+			if(_labelStyle == null) {
 				_labelStyle = new GUIStyle(EditorStyles.boldLabel);
 				_labelStyle.richText = true;
 			}
@@ -24,19 +20,15 @@ namespace NaughtyAttributes.Editor
 			return _labelStyle;
 		}
 
-		private string GetPropertyKeyName(SerializedProperty property)
-		{
+		private string GetPropertyKeyName(SerializedProperty property) {
 			return property.serializedObject.targetObject.GetInstanceID() + "." + property.name;
 		}
 
-		protected override float GetPropertyHeight_Internal(SerializedProperty property)
-		{
-			if (property.isArray)
-			{
+		protected override float GetPropertyHeight_Internal(SerializedProperty property) {
+			if(property.isArray) {
 				string key = GetPropertyKeyName(property);
 
-				if (_reorderableListsByPropertyName.TryGetValue(key, out ReorderableList reorderableList) == false)
-				{
+				if(_reorderableListsByPropertyName.TryGetValue(key, out ReorderableList reorderableList) == false) {
 					return 0;
 				}
 
@@ -46,25 +38,19 @@ namespace NaughtyAttributes.Editor
 			return EditorGUI.GetPropertyHeight(property, true);
 		}
 
-		protected override void OnGUI_Internal(Rect rect, SerializedProperty property, GUIContent label)
-		{
-			if (property.isArray)
-			{
+		protected override void OnGUI_Internal(Rect rect, SerializedProperty property, GUIContent label, SpecialCaseDrawerAttribute specialCaseAttribute) {
+			if(property.isArray) {
 				string key = GetPropertyKeyName(property);
 
 				ReorderableList reorderableList = null;
-				if (!_reorderableListsByPropertyName.ContainsKey(key))
-				{
-					reorderableList = new ReorderableList(property.serializedObject, property, true, true, true, true)
-					{
-						drawHeaderCallback = (Rect r) =>
-						{
+				if(!_reorderableListsByPropertyName.ContainsKey(key)) {
+					reorderableList = new ReorderableList(property.serializedObject, property, true, true, true, true) {
+						drawHeaderCallback = (Rect r) => {
 							EditorGUI.LabelField(r, string.Format("{0}: {1}", label.text, property.arraySize), GetLabelStyle());
 							HandleDragAndDrop(r, reorderableList);
 						},
 
-						drawElementCallback = (Rect r, int index, bool isActive, bool isFocused) =>
-						{
+						drawElementCallback = (Rect r, int index, bool isActive, bool isFocused) => {
 							SerializedProperty element = property.GetArrayElementAtIndex(index);
 							r.y += 1.0f;
 							r.x += 10.0f;
@@ -73,8 +59,7 @@ namespace NaughtyAttributes.Editor
 							EditorGUI.PropertyField(new Rect(r.x, r.y, r.width, EditorGUIUtility.singleLineHeight), element, true);
 						},
 
-						elementHeightCallback = (int index) =>
-						{
+						elementHeightCallback = (int index) => {
 							return EditorGUI.GetPropertyHeight(property.GetArrayElementAtIndex(index)) + 4.0f;
 						}
 					};
@@ -84,62 +69,46 @@ namespace NaughtyAttributes.Editor
 
 				reorderableList = _reorderableListsByPropertyName[key];
 
-				if (rect == default)
-				{
+				if(rect == default) {
 					reorderableList.DoLayoutList();
-				}
-				else
-				{
+				} else {
 					reorderableList.DoList(rect);
 				}
-			}
-			else
-			{
+			} else {
 				string message = typeof(ReorderableListAttribute).Name + " can be used only on arrays or lists";
 				NaughtyEditorGUI.HelpBox_Layout(message, MessageType.Warning, context: property.serializedObject.targetObject);
 				EditorGUILayout.PropertyField(property, true);
 			}
 		}
 
-		public void ClearCache()
-		{
+		public void ClearCache() {
 			_reorderableListsByPropertyName.Clear();
 		}
 
-		private Object GetAssignableObject(Object obj, ReorderableList list)
-		{
+		private Object GetAssignableObject(Object obj, ReorderableList list) {
 			System.Type listType = PropertyUtility.GetPropertyType(list.serializedProperty);
 			System.Type elementType = ReflectionUtility.GetListElementType(listType);
 
-			if (elementType == null)
-			{
+			if(elementType == null) {
 				return null;
 			}
 
 			System.Type objType = obj.GetType();
 
-			if (elementType.IsAssignableFrom(objType))
-			{
+			if(elementType.IsAssignableFrom(objType)) {
 				return obj;
 			}
 
-			if (objType == typeof(GameObject))
-			{
-				if (typeof(Transform).IsAssignableFrom(elementType))
-				{
+			if(objType == typeof(GameObject)) {
+				if(typeof(Transform).IsAssignableFrom(elementType)) {
 					Transform transform = ((GameObject)obj).transform;
-					if (elementType == typeof(RectTransform))
-					{
+					if(elementType == typeof(RectTransform)) {
 						RectTransform rectTransform = transform as RectTransform;
 						return rectTransform;
-					}
-					else
-					{
+					} else {
 						return transform;
 					}
-				}
-				else if (typeof(MonoBehaviour).IsAssignableFrom(elementType))
-				{
+				} else if(typeof(MonoBehaviour).IsAssignableFrom(elementType)) {
 					return ((GameObject)obj).GetComponent(elementType);
 				}
 			}
@@ -147,16 +116,13 @@ namespace NaughtyAttributes.Editor
 			return null;
 		}
 
-		private void HandleDragAndDrop(Rect rect, ReorderableList list)
-		{
+		private void HandleDragAndDrop(Rect rect, ReorderableList list) {
 			var currentEvent = Event.current;
 			var usedEvent = false;
 
-			switch (currentEvent.type)
-			{
+			switch(currentEvent.type) {
 				case EventType.DragExited:
-					if (GUI.enabled)
-					{
+					if(GUI.enabled) {
 						HandleUtility.Repaint();
 					}
 
@@ -164,19 +130,15 @@ namespace NaughtyAttributes.Editor
 
 				case EventType.DragUpdated:
 				case EventType.DragPerform:
-					if (rect.Contains(currentEvent.mousePosition) && GUI.enabled)
-					{
+					if(rect.Contains(currentEvent.mousePosition) && GUI.enabled) {
 						// Check each single object, so we can add multiple objects in a single drag.
 						bool didAcceptDrag = false;
 						Object[] references = DragAndDrop.objectReferences;
-						foreach (Object obj in references)
-						{
+						foreach(Object obj in references) {
 							Object assignableObject = GetAssignableObject(obj, list);
-							if (assignableObject != null)
-							{
+							if(assignableObject != null) {
 								DragAndDrop.visualMode = DragAndDropVisualMode.Copy;
-								if (currentEvent.type == EventType.DragPerform)
-								{
+								if(currentEvent.type == EventType.DragPerform) {
 									list.serializedProperty.arraySize++;
 									int arrayEnd = list.serializedProperty.arraySize - 1;
 									list.serializedProperty.GetArrayElementAtIndex(arrayEnd).objectReferenceValue = assignableObject;
@@ -185,8 +147,7 @@ namespace NaughtyAttributes.Editor
 							}
 						}
 
-						if (didAcceptDrag)
-						{
+						if(didAcceptDrag) {
 							GUI.changed = true;
 							DragAndDrop.AcceptDrag();
 							usedEvent = true;
@@ -196,8 +157,7 @@ namespace NaughtyAttributes.Editor
 					break;
 			}
 
-			if (usedEvent)
-			{
+			if(usedEvent) {
 				currentEvent.Use();
 			}
 		}

--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers_SpecialCase/SpecialCasePropertyDrawerBase.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers_SpecialCase/SpecialCasePropertyDrawerBase.cs
@@ -3,23 +3,18 @@ using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
 
-namespace NaughtyAttributes.Editor
-{
-	public abstract class SpecialCasePropertyDrawerBase
-	{
-		public void OnGUI(Rect rect, SerializedProperty property)
-		{
+namespace NaughtyAttributes.Editor {
+	public abstract class SpecialCasePropertyDrawerBase {
+		public void OnGUI(Rect rect, SerializedProperty property, SpecialCaseDrawerAttribute specialCaseAttribute) {
 			// Check if visible
 			bool visible = PropertyUtility.IsVisible(property);
-			if (!visible)
-			{
+			if(!visible) {
 				return;
 			}
 
 			// Validate
 			ValidatorAttribute[] validatorAttributes = PropertyUtility.GetAttributes<ValidatorAttribute>(property);
-			foreach (var validatorAttribute in validatorAttributes)
-			{
+			foreach(var validatorAttribute in validatorAttributes) {
 				validatorAttribute.GetValidator().ValidateProperty(property);
 			}
 
@@ -27,48 +22,54 @@ namespace NaughtyAttributes.Editor
 			EditorGUI.BeginChangeCheck();
 			bool enabled = PropertyUtility.IsEnabled(property);
 
-			using (new EditorGUI.DisabledScope(disabled: !enabled))
-			{
-				OnGUI_Internal(rect, property, PropertyUtility.GetLabel(property));
+			using(new EditorGUI.DisabledScope(disabled: !enabled)) {
+				OnGUI_Internal(rect, property, PropertyUtility.GetLabel(property), specialCaseAttribute);
 			}
 
 			// Call OnValueChanged callbacks
-			if (EditorGUI.EndChangeCheck())
-			{
+			if(EditorGUI.EndChangeCheck()) {
 				PropertyUtility.CallOnValueChangedCallbacks(property);
 			}
 		}
 
-		public float GetPropertyHeight(SerializedProperty property)
-		{
+		public float GetPropertyHeight(SerializedProperty property) {
 			return GetPropertyHeight_Internal(property);
 		}
 
-		protected abstract void OnGUI_Internal(Rect rect, SerializedProperty property, GUIContent label);
+		protected abstract void OnGUI_Internal(Rect rect, SerializedProperty property, GUIContent label, SpecialCaseDrawerAttribute specialCaseAttribute);
 		protected abstract float GetPropertyHeight_Internal(SerializedProperty property);
+
+		public virtual void Enable(SpecialCaseDrawerAttribute specialCaseAttribute, SerializedProperty prop) {
+		}
+		public virtual void Disable() {
+		}
 	}
 
-	public static class SpecialCaseDrawerAttributeExtensions
-	{
+	public static class SpecialCaseDrawerAttributeExtensions {
 		private static Dictionary<Type, SpecialCasePropertyDrawerBase> _drawersByAttributeType;
 
-		static SpecialCaseDrawerAttributeExtensions()
-		{
+		static SpecialCaseDrawerAttributeExtensions() {
 			_drawersByAttributeType = new Dictionary<Type, SpecialCasePropertyDrawerBase>();
 			_drawersByAttributeType[typeof(ReorderableListAttribute)] = ReorderableListPropertyDrawer.Instance;
+
 		}
 
-		public static SpecialCasePropertyDrawerBase GetDrawer(this SpecialCaseDrawerAttribute attr)
-		{
+		public static SpecialCasePropertyDrawerBase GetDrawer(this SpecialCaseDrawerAttribute attr, SerializedProperty prop) {
 			SpecialCasePropertyDrawerBase drawer;
-			if (_drawersByAttributeType.TryGetValue(attr.GetType(), out drawer))
-			{
-				return drawer;
+
+			if(attr is HexBrushAttribute) {
+				if(MultipleSpecialDrawer.Exists(prop)) {
+					return MultipleSpecialDrawer.GetDrawer(prop);
+				} else
+					return new HexBrushPropertyDrawer(prop, attr);
 			}
-			else
-			{
+
+			if(_drawersByAttributeType.TryGetValue(attr.GetType(), out drawer)) {
+				return drawer;
+			} else {
 				return null;
 			}
 		}
+
 	}
 }

--- a/Assets/NaughtyAttributes/Scripts/Editor/Utility.meta
+++ b/Assets/NaughtyAttributes/Scripts/Editor/Utility.meta
@@ -2,7 +2,7 @@ fileFormatVersion: 2
 guid: acb4475c71a3fe947a81ced84ab89c6d
 folderAsset: yes
 timeCreated: 1508062761
-licenseType: Free
+licenseType: Store
 DefaultImporter:
   externalObjects: {}
   userData: 

--- a/Assets/NaughtyAttributes/Scripts/Editor/Utility/NaughtyEditorGUI.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/Utility/NaughtyEditorGUI.cs
@@ -7,10 +7,8 @@ using UnityEditor.Experimental.SceneManagement;
 using UnityEditor.SceneManagement;
 using UnityEngine;
 
-namespace NaughtyAttributes.Editor
-{
-	public static class NaughtyEditorGUI
-	{
+namespace NaughtyAttributes.Editor {
+	public static class NaughtyEditorGUI {
 		public const float IndentLength = 15.0f;
 		public const float HorizontalSpacing = 2.0f;
 
@@ -18,47 +16,37 @@ namespace NaughtyAttributes.Editor
 
 		private delegate void PropertyFieldFunction(Rect rect, SerializedProperty property, GUIContent label, bool includeChildren);
 
-		public static void PropertyField(Rect rect, SerializedProperty property, bool includeChildren)
-		{
+		public static void PropertyField(Rect rect, SerializedProperty property, bool includeChildren) {
 			PropertyField_Implementation(rect, property, includeChildren, DrawPropertyField);
 		}
 
-		public static void PropertyField_Layout(SerializedProperty property, bool includeChildren)
-		{
+		public static void PropertyField_Layout(SerializedProperty property, bool includeChildren) {
 			Rect dummyRect = new Rect();
 			PropertyField_Implementation(dummyRect, property, includeChildren, DrawPropertyField_Layout);
 		}
 
-		private static void DrawPropertyField(Rect rect, SerializedProperty property, GUIContent label, bool includeChildren)
-		{
+		private static void DrawPropertyField(Rect rect, SerializedProperty property, GUIContent label, bool includeChildren) {
 			EditorGUI.PropertyField(rect, property, label, includeChildren);
 		}
 
-		private static void DrawPropertyField_Layout(Rect rect, SerializedProperty property, GUIContent label, bool includeChildren)
-		{
+		private static void DrawPropertyField_Layout(Rect rect, SerializedProperty property, GUIContent label, bool includeChildren) {
 			EditorGUILayout.PropertyField(property, label, includeChildren);
 		}
 
-		private static void PropertyField_Implementation(Rect rect, SerializedProperty property, bool includeChildren, PropertyFieldFunction propertyFieldFunction)
-		{
+		private static void PropertyField_Implementation(Rect rect, SerializedProperty property, bool includeChildren, PropertyFieldFunction propertyFieldFunction) {
 			SpecialCaseDrawerAttribute specialCaseAttribute = PropertyUtility.GetAttribute<SpecialCaseDrawerAttribute>(property);
-			if (specialCaseAttribute != null)
-			{
-				specialCaseAttribute.GetDrawer().OnGUI(rect, property);
-			}
-			else
-			{
+			if(specialCaseAttribute != null) {
+				specialCaseAttribute.GetDrawer(property).OnGUI(rect, property, specialCaseAttribute);
+			} else {
 				// Check if visible
 				bool visible = PropertyUtility.IsVisible(property);
-				if (!visible)
-				{
+				if(!visible) {
 					return;
 				}
 
 				// Validate
 				ValidatorAttribute[] validatorAttributes = PropertyUtility.GetAttributes<ValidatorAttribute>(property);
-				foreach (var validatorAttribute in validatorAttributes)
-				{
+				foreach(var validatorAttribute in validatorAttributes) {
 					validatorAttribute.GetValidator().ValidateProperty(property);
 				}
 
@@ -66,38 +54,32 @@ namespace NaughtyAttributes.Editor
 				EditorGUI.BeginChangeCheck();
 				bool enabled = PropertyUtility.IsEnabled(property);
 
-				using (new EditorGUI.DisabledScope(disabled: !enabled))
-				{
+				using(new EditorGUI.DisabledScope(disabled: !enabled)) {
 					propertyFieldFunction.Invoke(rect, property, PropertyUtility.GetLabel(property), includeChildren);
 				}
 
 				// Call OnValueChanged callbacks
-				if (EditorGUI.EndChangeCheck())
-				{
+				if(EditorGUI.EndChangeCheck()) {
 					PropertyUtility.CallOnValueChangedCallbacks(property);
 				}
 			}
 		}
 
-		public static float GetIndentLength(Rect sourceRect)
-		{
+		public static float GetIndentLength(Rect sourceRect) {
 			Rect indentRect = EditorGUI.IndentedRect(sourceRect);
 			float indentLength = indentRect.x - sourceRect.x;
 
 			return indentLength;
 		}
 
-		public static void BeginBoxGroup_Layout(string label = "")
-		{
+		public static void BeginBoxGroup_Layout(string label = "") {
 			EditorGUILayout.BeginVertical(GUI.skin.box);
-			if (!string.IsNullOrEmpty(label))
-			{
+			if(!string.IsNullOrEmpty(label)) {
 				EditorGUILayout.LabelField(label, EditorStyles.boldLabel);
 			}
 		}
 
-		public static void EndBoxGroup_Layout()
-		{
+		public static void EndBoxGroup_Layout() {
 			EditorGUILayout.EndVertical();
 		}
 
@@ -114,16 +96,14 @@ namespace NaughtyAttributes.Editor
 		/// <param name="displayOptions">The display options for the values</param>
 		public static void Dropdown(
 			Rect rect, SerializedObject serializedObject, object target, FieldInfo dropdownField,
-			string label, int selectedValueIndex, object[] values, string[] displayOptions)
-		{
+			string label, int selectedValueIndex, object[] values, string[] displayOptions) {
 			EditorGUI.BeginChangeCheck();
 
 			int newIndex = EditorGUI.Popup(rect, label, selectedValueIndex, displayOptions);
 			object newValue = values[newIndex];
 
 			object dropdownValue = dropdownField.GetValue(target);
-			if (dropdownValue == null || !dropdownValue.Equals(newValue))
-			{
+			if(dropdownValue == null || !dropdownValue.Equals(newValue)) {
 				Undo.RecordObject(serializedObject.targetObject, "Dropdown");
 
 				// TODO: Problem with structs, because they are value type.
@@ -132,16 +112,13 @@ namespace NaughtyAttributes.Editor
 			}
 		}
 
-		public static void Button(UnityEngine.Object target, MethodInfo methodInfo)
-		{
+		public static void Button(UnityEngine.Object target, MethodInfo methodInfo) {
 			bool visible = ButtonUtility.IsVisible(target, methodInfo);
-			if (!visible)
-			{
+			if(!visible) {
 				return;
 			}
 
-			if (methodInfo.GetParameters().All(p => p.IsOptional))
-			{
+			if(methodInfo.GetParameters().All(p => p.IsOptional)) {
 				ButtonAttribute buttonAttribute = (ButtonAttribute)methodInfo.GetCustomAttributes(typeof(ButtonAttribute), true)[0];
 				string buttonText = string.IsNullOrEmpty(buttonAttribute.Text) ? ObjectNames.NicifyVariableName(methodInfo.Name) : buttonAttribute.Text;
 
@@ -154,205 +131,135 @@ namespace NaughtyAttributes.Editor
 					mode == EButtonEnableMode.Playmode && Application.isPlaying;
 
 				bool methodIsCoroutine = methodInfo.ReturnType == typeof(IEnumerator);
-				if (methodIsCoroutine)
-				{
+				if(methodIsCoroutine) {
 					buttonEnabled &= (Application.isPlaying ? true : false);
 				}
 
 				EditorGUI.BeginDisabledGroup(!buttonEnabled);
 
-				if (GUILayout.Button(buttonText, _buttonStyle))
-				{
+				if(GUILayout.Button(buttonText, _buttonStyle)) {
 					object[] defaultParams = methodInfo.GetParameters().Select(p => p.DefaultValue).ToArray();
 					IEnumerator methodResult = methodInfo.Invoke(target, defaultParams) as IEnumerator;
 
-					if (!Application.isPlaying)
-					{
+					if(!Application.isPlaying) {
 						// Set target object and scene dirty to serialize changes to disk
 						EditorUtility.SetDirty(target);
 
 						PrefabStage stage = PrefabStageUtility.GetCurrentPrefabStage();
-						if (stage != null)
-						{
+						if(stage != null) {
 							// Prefab mode
 							EditorSceneManager.MarkSceneDirty(stage.scene);
-						}
-						else
-						{
+						} else {
 							// Normal scene
 							EditorSceneManager.MarkSceneDirty(EditorSceneManager.GetActiveScene());
 						}
-					}
-					else if (methodResult != null && target is MonoBehaviour behaviour)
-					{
+					} else if(methodResult != null && target is MonoBehaviour behaviour) {
 						behaviour.StartCoroutine(methodResult);
 					}
 				}
 
 				EditorGUI.EndDisabledGroup();
-			}
-			else
-			{
+			} else {
 				string warning = typeof(ButtonAttribute).Name + " works only on methods with no parameters";
 				HelpBox_Layout(warning, MessageType.Warning, context: target, logToConsole: true);
 			}
 		}
 
-		public static void NativeProperty_Layout(UnityEngine.Object target, PropertyInfo property)
-		{
+		public static void NativeProperty_Layout(UnityEngine.Object target, PropertyInfo property) {
 			object value = property.GetValue(target, null);
 
-			if (value == null)
-			{
+			if(value == null) {
 				string warning = string.Format("{0} is null. {1} doesn't support reference types with null value", property.Name, typeof(ShowNativePropertyAttribute).Name);
 				HelpBox_Layout(warning, MessageType.Warning, context: target);
-			}
-			else if (!Field_Layout(value, property.Name))
-			{
+			} else if(!Field_Layout(value, property.Name)) {
 				string warning = string.Format("{0} doesn't support {1} types", typeof(ShowNativePropertyAttribute).Name, property.PropertyType.Name);
 				HelpBox_Layout(warning, MessageType.Warning, context: target);
 			}
 		}
 
-		public static void NonSerializedField_Layout(UnityEngine.Object target, FieldInfo field)
-		{
+		public static void NonSerializedField_Layout(UnityEngine.Object target, FieldInfo field) {
 			object value = field.GetValue(target);
 
-			if (value == null)
-			{
+			if(value == null) {
 				string warning = string.Format("{0} is null. {1} doesn't support reference types with null value", field.Name, typeof(ShowNonSerializedFieldAttribute).Name);
 				HelpBox_Layout(warning, MessageType.Warning, context: target);
-			}
-			else if (!Field_Layout(value, field.Name))
-			{
+			} else if(!Field_Layout(value, field.Name)) {
 				string warning = string.Format("{0} doesn't support {1} types", typeof(ShowNonSerializedFieldAttribute).Name, field.FieldType.Name);
 				HelpBox_Layout(warning, MessageType.Warning, context: target);
 			}
 		}
 
-		public static void HorizontalLine(Rect rect, float height, Color color)
-		{
+		public static void HorizontalLine(Rect rect, float height, Color color) {
 			rect.height = height;
 			EditorGUI.DrawRect(rect, color);
 		}
 
-		public static void HelpBox(Rect rect, string message, MessageType type, UnityEngine.Object context = null, bool logToConsole = false)
-		{
+		public static void HelpBox(Rect rect, string message, MessageType type, UnityEngine.Object context = null, bool logToConsole = false) {
 			EditorGUI.HelpBox(rect, message, type);
 
-			if (logToConsole)
-			{
+			if(logToConsole) {
 				DebugLogMessage(message, type, context);
 			}
 		}
 
-		public static void HelpBox_Layout(string message, MessageType type, UnityEngine.Object context = null, bool logToConsole = false)
-		{
+		public static void HelpBox_Layout(string message, MessageType type, UnityEngine.Object context = null, bool logToConsole = false) {
 			EditorGUILayout.HelpBox(message, type);
 
-			if (logToConsole)
-			{
+			if(logToConsole) {
 				DebugLogMessage(message, type, context);
 			}
 		}
 
-		public static bool Field_Layout(object value, string label)
-		{
-			using (new EditorGUI.DisabledScope(disabled: true))
-			{
+		public static bool Field_Layout(object value, string label) {
+			using(new EditorGUI.DisabledScope(disabled: true)) {
 				bool isDrawn = true;
 				Type valueType = value.GetType();
 
-				if (valueType == typeof(bool))
-				{
+				if(valueType == typeof(bool)) {
 					EditorGUILayout.Toggle(label, (bool)value);
-				}
-				else if (valueType == typeof(short))
-				{
+				} else if(valueType == typeof(short)) {
 					EditorGUILayout.IntField(label, (short)value);
-				}
-				else if (valueType == typeof(ushort))
-				{
+				} else if(valueType == typeof(ushort)) {
 					EditorGUILayout.IntField(label, (ushort)value);
-				}
-				else if (valueType == typeof(int))
-				{
+				} else if(valueType == typeof(int)) {
 					EditorGUILayout.IntField(label, (int)value);
-				}
-				else if (valueType == typeof(uint))
-				{
+				} else if(valueType == typeof(uint)) {
 					EditorGUILayout.LongField(label, (uint)value);
-				}
-				else if (valueType == typeof(long))
-				{
+				} else if(valueType == typeof(long)) {
 					EditorGUILayout.LongField(label, (long)value);
-				}
-				else if (valueType == typeof(ulong))
-				{
+				} else if(valueType == typeof(ulong)) {
 					EditorGUILayout.TextField(label, ((ulong)value).ToString());
-				}
-				else if (valueType == typeof(float))
-				{
+				} else if(valueType == typeof(float)) {
 					EditorGUILayout.FloatField(label, (float)value);
-				}
-				else if (valueType == typeof(double))
-				{
+				} else if(valueType == typeof(double)) {
 					EditorGUILayout.DoubleField(label, (double)value);
-				}
-				else if (valueType == typeof(string))
-				{
+				} else if(valueType == typeof(string)) {
 					EditorGUILayout.TextField(label, (string)value);
-				}
-				else if (valueType == typeof(Vector2))
-				{
+				} else if(valueType == typeof(Vector2)) {
 					EditorGUILayout.Vector2Field(label, (Vector2)value);
-				}
-				else if (valueType == typeof(Vector3))
-				{
+				} else if(valueType == typeof(Vector3)) {
 					EditorGUILayout.Vector3Field(label, (Vector3)value);
-				}
-				else if (valueType == typeof(Vector4))
-				{
+				} else if(valueType == typeof(Vector4)) {
 					EditorGUILayout.Vector4Field(label, (Vector4)value);
-				}
-				else if (valueType == typeof(Vector2Int))
-				{
+				} else if(valueType == typeof(Vector2Int)) {
 					EditorGUILayout.Vector2IntField(label, (Vector2Int)value);
-				}
-				else if (valueType == typeof(Vector3Int))
-				{
+				} else if(valueType == typeof(Vector3Int)) {
 					EditorGUILayout.Vector3IntField(label, (Vector3Int)value);
-				}
-				else if (valueType == typeof(Color))
-				{
+				} else if(valueType == typeof(Color)) {
 					EditorGUILayout.ColorField(label, (Color)value);
-				}
-				else if (valueType == typeof(Bounds))
-				{
+				} else if(valueType == typeof(Bounds)) {
 					EditorGUILayout.BoundsField(label, (Bounds)value);
-				}
-				else if (valueType == typeof(Rect))
-				{
+				} else if(valueType == typeof(Rect)) {
 					EditorGUILayout.RectField(label, (Rect)value);
-				}
-				else if (valueType == typeof(RectInt))
-				{
+				} else if(valueType == typeof(RectInt)) {
 					EditorGUILayout.RectIntField(label, (RectInt)value);
-				}
-				else if (typeof(UnityEngine.Object).IsAssignableFrom(valueType))
-				{
+				} else if(typeof(UnityEngine.Object).IsAssignableFrom(valueType)) {
 					EditorGUILayout.ObjectField(label, (UnityEngine.Object)value, valueType, true);
-				}
-				else if (valueType.BaseType == typeof(Enum))
-				{
+				} else if(valueType.BaseType == typeof(Enum)) {
 					EditorGUILayout.EnumPopup(label, (Enum)value);
-				}
-				else if (valueType.BaseType == typeof(System.Reflection.TypeInfo))
-				{
+				} else if(valueType.BaseType == typeof(System.Reflection.TypeInfo)) {
 					EditorGUILayout.TextField(label, value.ToString());
-				}
-				else
-				{
+				} else {
 					isDrawn = false;
 				}
 
@@ -360,10 +267,8 @@ namespace NaughtyAttributes.Editor
 			}
 		}
 
-		private static void DebugLogMessage(string message, MessageType type, UnityEngine.Object context)
-		{
-			switch (type)
-			{
+		private static void DebugLogMessage(string message, MessageType type, UnityEngine.Object context) {
+			switch(type) {
 				case MessageType.None:
 				case MessageType.Info:
 					Debug.Log(message, context);

--- a/Assets/NaughtyAttributes/Scripts/Editor/Utility/NaughtyEditorGUI.cs.meta
+++ b/Assets/NaughtyAttributes/Scripts/Editor/Utility/NaughtyEditorGUI.cs.meta
@@ -1,7 +1,7 @@
 fileFormatVersion: 2
 guid: 6ff27ff7705d6064e935bb2159a1b453
 timeCreated: 1510926159
-licenseType: Free
+licenseType: Store
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/NaughtyAttributes/Scripts/Editor/Utility/ReflectionUtility.cs.meta
+++ b/Assets/NaughtyAttributes/Scripts/Editor/Utility/ReflectionUtility.cs.meta
@@ -1,7 +1,7 @@
 fileFormatVersion: 2
 guid: 1d86c581f02a55f458e36bf7e81e3084
 timeCreated: 1520258793
-licenseType: Free
+licenseType: Store
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/NaughtyAttributes/Scripts/HexSystem.cs
+++ b/Assets/NaughtyAttributes/Scripts/HexSystem.cs
@@ -1,0 +1,412 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+[System.Serializable]
+public struct HexData {
+	public static readonly float hexRatio = 0.86603f;
+	public static readonly float outerRadius = 0.5f;
+	public static readonly float innerRadius = outerRadius * hexRatio;
+	public static readonly float levelHeigth = 0.6f;
+
+	public static readonly Vector3 yAxis = Vector3.forward;
+	public static readonly Vector3 xAxis = Quaternion.AngleAxis(60, Vector3.up) * yAxis;
+	public static readonly Vector3 ortho = Vector3.Cross(yAxis, xAxis);
+
+}
+
+[System.Serializable]
+public struct HexVector {
+	public enum direction { up, upR, downR, down, downL, upL, zero }
+
+	public int x, y;
+
+	public int z { get { return -x - y; } }
+	public int magnitude {
+		get {
+			return (Mathf.Abs(x) + Mathf.Abs(y) + Mathf.Abs(z)) / 2;
+		}
+	}
+
+
+	public int angle {
+		get {
+			return GetRotation(up, this.normalize);
+		}
+	}
+
+	public HexVector(int x, int y) {
+		this.x = x;
+		this.y = y;
+	}
+
+	public HexVector(Vector3 pos) {
+		this = GetHex(pos);
+	}
+
+	public override string ToString() {
+		return "HexVector(" + x + ", " + y + ")";
+	}
+	public string ToShortString() {
+		return "(" + x + ", " + y + ")";
+	}
+
+	public bool TryParse(string val, out HexVector v) {
+		if(val.Contains("HexVector"))
+			val = val.Remove(0, "HexVector".Length);
+
+		val.Trim('(', ')', ',');
+		string[] xy = val.Split(' ');
+		int x = int.Parse(xy[0]);
+		int y = int.Parse(xy[1]);
+		v = new HexVector(x, y);
+		return true;
+	}
+
+	public Vector3 Cartesian {
+		get {
+			return (HexData.xAxis * x + HexData.yAxis * y) * HexData.innerRadius * 2;
+		}
+	}
+
+	public HexVector Rotate(int tiles) {
+		tiles = tiles % 6;
+
+
+		int xR = x,
+			yR = y,
+			zR = z;
+		int xTemp, yTemp, zTemp;
+		if(tiles >= 0) {
+			for(int i = 0; i < tiles; i++) {
+				xTemp = xR;
+				yTemp = yR;
+				zTemp = zR;
+
+				xR = -zTemp;
+				yR = -xTemp;
+				zR = -yTemp;
+
+			}
+		} else {
+			for(int i = 0; i < -tiles; i++) {
+				xTemp = xR;
+				yTemp = yR;
+				zTemp = zR;
+
+				xR = -yTemp;
+				yR = -zTemp;
+				zR = -xTemp;
+
+			}
+		}
+		return new HexVector(xR, yR);
+	}
+
+	public direction GetDirection() {
+		if(this == HexVector.up)
+			return direction.up;
+		if(this == downR)
+			return direction.downR;
+		if(this == upR)
+			return direction.upR;
+		if(this == -upR)
+			return direction.downL;
+		if(this == -downR)
+			return direction.upL;
+		if(this == -up)
+			return direction.down;
+		return direction.zero;
+	}
+
+	public HexVector CircleRotate(int tiles) {
+		int d = magnitude;
+		HexVector g = this;
+		//skrót przez rotację o pełne hexy
+
+		for(int i = 0; i < tiles; i++) {
+			if(Mathf.Abs(g.x) == d) {
+				if(Mathf.Abs(g.y) == d) {
+					g += downL * Math.Sign(g.x);
+					continue;
+				}
+				g += down * Math.Sign(g.x);
+				continue;
+			}
+
+			if(Mathf.Abs(g.y) == d) {
+				if(Mathf.Abs(g.z) == d) {
+					g += downR * Math.Sign(g.y);
+					continue;
+				}
+				g += upR * Math.Sign(g.y);
+				continue;
+			}
+			g += downR * Math.Sign(g.y);
+		}
+
+
+		for(int i = 0; i > tiles; i--) {
+
+			if(Mathf.Abs(g.y) == d) {
+				if(Mathf.Abs(g.x) == d) {
+					g += up * Math.Sign(g.x);
+					continue;
+				}
+				g += downL * Math.Sign(g.y);
+				continue;
+			}
+			if(Mathf.Abs(g.x) == d) {
+				if(Mathf.Abs(g.z) == d) {
+					g += upL * Math.Sign(g.x);
+					continue;
+				}
+				g += up * Math.Sign(g.x);
+				continue;
+			}
+
+			g += upL * Math.Sign(g.y);
+		}
+
+		return g;
+
+	}
+
+	public HexVector normalize {
+		get {
+			return GetHex(Cartesian.normalized);
+			//return new HexVector(Mathf.Clamp(this.x, -1, 1), Mathf.Clamp(this.y, -1, 1));
+		}
+	}
+	public bool CanNormalize() {
+		if(x == 0 || y == 0 || z == 0)
+			return true;
+		else
+			return false;
+	}
+	public Vector3 GetCorner(int index) {
+
+		return Cartesian + Quaternion.AngleAxis(-30 + index * 60, HexData.ortho) * (HexData.yAxis * HexData.outerRadius);
+	}
+
+	public Vector3 GetEdgeCenter(int index) {
+		return Cartesian + Quaternion.AngleAxis(-60 * index, HexData.ortho) * (HexData.yAxis * HexData.innerRadius);
+	}
+
+	public HexVector[] subdivide {
+		get {
+			HexVector[] p = new HexVector[2];
+			p[0] = new HexVector(x / 2, 0);
+			p[1] = new HexVector(0, y / 2);
+
+			p[0].y = y - p[1].y;
+			p[1].x = x - p[0].x;
+			//p[1] = new HexVector(x - p[0].x, y - p[0].y);
+			return p;
+		}
+	}
+
+
+	//statics
+	public readonly static HexVector zero = new HexVector(0, 0);
+	public readonly static HexVector up = new HexVector(0, 1);
+	public readonly static HexVector down = new HexVector(0, -1);
+
+	public readonly static HexVector upR = new HexVector(1, 0);
+	public readonly static HexVector upL = new HexVector(-1, 1);
+
+	public readonly static HexVector downL = new HexVector(-1, 0);
+	public readonly static HexVector downR = new HexVector(1, -1);
+
+
+	public static HexVector operator +(HexVector a, HexVector b) {
+		return new HexVector(a.x + b.x, a.y + b.y);
+	}
+	public static HexVector operator -(HexVector a, HexVector b) {
+		return new HexVector(a.x - b.x, a.y - b.y);
+	}
+	public static HexVector operator -(HexVector a) {
+		return new HexVector(-a.x, -a.y);
+	}
+	public static HexVector operator *(HexVector a, int v) {
+		return new HexVector(a.x * v, a.y * v);
+	}
+
+	public static bool operator ==(HexVector a, HexVector b) {
+		return (a.x == b.x && a.y == b.y);
+	}
+	public static bool operator !=(HexVector a, HexVector b) {
+		return !(a.x == b.x && a.y == b.y);
+	}
+
+	public static explicit operator Vector2Int(HexVector v) {
+		return new Vector2Int(v.x, v.y);
+	}
+
+	public static HexVector GetHex(Vector3 pos) {
+
+		float y = Vector3.Dot(pos, HexData.yAxis) / (HexData.innerRadius * 2);
+		float z = -y;
+
+		float offset = pos.x / (HexData.outerRadius * 3);
+
+		y -= offset;
+		z -= offset;
+
+		float x = -z - y;
+
+
+
+		int iX = Mathf.RoundToInt(x);
+		int iY = Mathf.RoundToInt(y);
+		int iZ = Mathf.RoundToInt(z);
+
+		if(iX + iY + iZ != 0) {
+			float dX = Mathf.Abs(x - iX);
+			float dY = Mathf.Abs(y - iY);
+			float dZ = Mathf.Abs(z - iZ);
+
+			if(dX > dY && dX > dZ) {
+				iX = -iY - iZ;
+			} else if(dY > dZ) {
+				iY = -iZ - iX;
+			}
+		}
+
+
+		return new HexVector(iX, iY);
+	}
+
+	public static HexVector Direction(Vector3 v, int row) {
+		v = Vector3.ProjectOnPlane(v, HexData.ortho).normalized * HexData.hexRatio * row;
+		return GetHex(v);      //nieładnie :/ 
+	}
+
+	public static Vector3 SnapDirection(Vector3 v) {
+		return (Direction(v, 1)).Cartesian;
+	}
+
+	public static Quaternion HexRotation(int v, int row) {
+		return Quaternion.AngleAxis(v * 60f / row, HexData.ortho);
+	}
+	public static Vector3 Snap(Vector3 pos) {
+		return (GetHex(pos)).Cartesian;
+	}
+	public Quaternion Rotation {
+		get {
+			return Quaternion.LookRotation(this.Cartesian.normalized, HexData.ortho);
+		}
+	}
+	public static int GetRotation(HexVector r, HexVector v) {
+
+		if(r == v)
+			return 0;
+
+		for(int i = 1; i < 4; i++) {
+			r = r.Rotate(1);
+			if(r == v)
+				return i;
+		}
+
+		for(int i = 0; i < 2; i++) {
+			r = r.Rotate(1);
+			if(r == v)
+				return i - 2;
+		}
+
+		return 0;
+	}
+
+	public override bool Equals(object obj) {
+		if(!(obj is HexVector)) {
+			return false;
+		}
+
+		var vector = (HexVector)obj;
+		return x == vector.x &&
+			   y == vector.y;
+	}
+
+	public override int GetHashCode() {
+		var hashCode = -1476677902;
+		hashCode = hashCode * -1521134295 + x.GetHashCode();
+		hashCode = hashCode * -1521134295 + y.GetHashCode();
+		return hashCode;
+	}
+
+	public static Quaternion SnappedRotation(Transform t) {
+		return Quaternion.LookRotation(SnapDirection(t.forward));
+	}
+
+	public static HexVector[] Line(HexVector from, HexVector to) {
+		HexVector l = to - from;
+		if(l == HexVector.zero)
+			return new HexVector[] { from };
+
+		Vector3 step = l.Cartesian / l.magnitude;
+		HexVector[] points = new HexVector[l.magnitude + 1];
+		for(int i = 0; i < l.magnitude + 1; i++) {
+			points[i] = from + GetHex(step * (i));
+		}
+		return points;
+	}
+
+	public static HexVector[] neighbours = new HexVector[]{
+		up, upR, downR, down, downL,upL    };
+
+}
+public struct HexBorder {
+	public int value { get; private set; }
+	public HexBorder(HexVector[] open) {
+		value = 0b00111111;
+		foreach(HexVector a in open) {
+			value &= ~DirToBorder[a];
+		}
+	}
+	public HexBorder(int val) {
+		value = val;
+	}
+
+	public void Add(HexVector v) {
+		value |= DirToBorder[v];
+	}
+	public void Remove(HexVector v) {
+		value &= ~DirToBorder[v];
+	}
+	public bool Allowed(HexVector v) {
+		int s = (DirToBorder[v] & value);
+		return s != 0;
+	}
+
+	static Dictionary<HexVector, byte> DirToBorder = new Dictionary<HexVector, byte> { // równiedobrze można by brać rotację wektora i przekęcać o << 1 
+		{ HexVector.zero,   0b0     },
+		{ HexVector.up,     0b1     },
+		{ HexVector.upR,    0b10    },
+		{ HexVector.downR,  0b100   },
+		{ HexVector.down,   0b1000  },
+		{ HexVector.downL,  0b10000 },
+		{ HexVector.upL,    0b100000},
+	};
+
+
+}
+
+/*
+ public static int[] options = new int[] {
+		0b000000,
+		0b000001,
+		0b000011,
+		0b000111,
+		0b001111,
+		0b011111 ,
+
+		0b000101,
+		0b001101,
+		0b011101,
+		0b010101,
+		0b001001,
+		0b001011,
+		0b011011,
+		0b111111
+	};
+*/

--- a/Assets/NaughtyAttributes/Scripts/HexSystem.cs.meta
+++ b/Assets/NaughtyAttributes/Scripts/HexSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 01b466f0efb50ac459652699d0eda874
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/NaughtyAttributes/Scripts/Test/_NaughtyComponent.cs.meta
+++ b/Assets/NaughtyAttributes/Scripts/Test/_NaughtyComponent.cs.meta
@@ -1,7 +1,7 @@
 fileFormatVersion: 2
 guid: 9c928ea15ae74a44089beb2e534c1a35
 timeCreated: 1507996629
-licenseType: Free
+licenseType: Store
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/NaughtyAttributes/Scripts/Test/_NaughtyScriptableObject.cs.meta
+++ b/Assets/NaughtyAttributes/Scripts/Test/_NaughtyScriptableObject.cs.meta
@@ -1,7 +1,7 @@
 fileFormatVersion: 2
 guid: 753bdb918c6038142acddbd7aae6958f
 timeCreated: 1518639587
-licenseType: Free
+licenseType: Store
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2021.1.20f1
-m_EditorVersionWithRevision: 2021.1.20f1 (be552157821d)
+m_EditorVersion: 2020.3.20f1
+m_EditorVersionWithRevision: 2020.3.20f1 (41c4e627c95f)


### PR DESCRIPTION
I'm making hex grid tools and I've used your package to make a tool to select an array of hex positions on grid in scene view and serialize it.

![obraz](https://user-images.githubusercontent.com/13623509/142892442-136790be-4a07-4b23-a167-c70cd0389b86.png)

Problems solved: 
Special drawers were static, making it impossible for editing multiple arrays independently. Added support for multiple independent editing as well as Enable, Disable function calls.
Supports diffrent kinds of brushes (defined in attributes).
![obraz](https://user-images.githubusercontent.com/13623509/142890896-9ee0a5d7-1cdd-4eb8-820c-3150b00f3de5.png)
Editor view, allows for clearing the array and using provided hex brush for selecting.



![obraz](https://user-images.githubusercontent.com/13623509/142891299-c74879fb-58b4-407e-b1b0-6a2d68ed3033.png)
Scene view (green- brush, blue - serialised positions)


