### PR TITLE
Fix bug where fields preceding `ExpandableAttribute` were not modifiable (#294)

### DIFF
--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/ExpandablePropertyDrawer.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/ExpandablePropertyDrawer.cs
@@ -71,7 +71,6 @@ namespace NaughtyAttributes.Editor
 		protected override void OnGUI_Internal(Rect rect, SerializedProperty property, GUIContent label)
 		{
 			EditorGUI.BeginProperty(rect, label, property);
-			property.serializedObject.Update();
 
 			if (property.objectReferenceValue == null)
 			{

--- a/Assets/NaughtyAttributes/Scripts/Test/ExpandableTest.cs
+++ b/Assets/NaughtyAttributes/Scripts/Test/ExpandableTest.cs
@@ -4,6 +4,9 @@ namespace NaughtyAttributes.Test
 {
 	public class ExpandableTest : MonoBehaviour
 	{
+		// See #294
+		public int precedingField = 5;
+
 		[Expandable]
 		public ScriptableObject obj0;
 


### PR DESCRIPTION
Please refer to #294 for my investigation notes and uncertainties around intent of removed line.

Closes #294

