### PR TITLE
Curve Range for Arrays/List

### DIFF
--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/CurveRangePropertyDrawer.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/CurveRangePropertyDrawer.cs
@@ -27,13 +27,14 @@ namespace NaughtyAttributes.Editor
 				return;
 			}
 
-			var attribute = PropertyUtility.GetAttribute<CurveRangeAttribute>(property);
+			var curveRangeAttribute = (CurveRangeAttribute)attribute;
+			var curveRanges = new Rect(curveRangeAttribute.Min.x, curveRangeAttribute.Min.y, curveRangeAttribute.Max.x - curveRangeAttribute.Min.x, curveRangeAttribute.Max.y - curveRangeAttribute.Min.y);
 
 			EditorGUI.CurveField(
 				rect, 
 				property,
-				attribute.Color == EColor.Clear ? Color.green : attribute.Color.GetColor(),
-				new Rect(attribute.Min.x, attribute.Min.y, attribute.Max.x - attribute.Min.x, attribute.Max.y - attribute.Min.y),
+				curveRangeAttribute.Color == EColor.Clear ? Color.green : curveRangeAttribute.Color.GetColor(),
+				curveRanges,
 				label);
 
 			EditorGUI.EndProperty();


### PR DESCRIPTION
```csharp
using NaughtyAttributes;
using UnityEngine;

public class TestScript : MonoBehaviour
{
    [CurveRange(0f, 0f, 1f, 1f, EColor.Blue)]
    public AnimationCurve[] curves;
}
```

With the script above, previous output was like this:
![image](https://user-images.githubusercontent.com/27922283/152345611-ad02e261-95ee-49ff-904a-86b618e0be76.png)

Fixed it to look like this:
![image](https://user-images.githubusercontent.com/27922283/152345171-b95e72db-ecae-4a08-81cc-19f984aefab6.png)
