### PR TITLE
Splitting Fields drawing to it's own overrideable method

### DIFF
--- a/Assets/NaughtyAttributes/Scripts/Editor/NaughtyInspector.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/NaughtyInspector.cs
@@ -35,6 +35,15 @@ namespace NaughtyAttributes.Editor
 
         public override void OnInspectorGUI()
         {
+            DrawFields();
+
+            DrawNonSerializedFields();
+            DrawNativeProperties();
+            DrawButtons();
+        }
+
+        protected virtual void DrawFields()
+        {
             GetSerializedProperties(ref _serializedProperties);
 
             bool anyNaughtyAttribute = _serializedProperties.Any(p => PropertyUtility.GetAttribute<INaughtyAttribute>(p) != null);
@@ -46,10 +55,6 @@ namespace NaughtyAttributes.Editor
             {
                 DrawSerializedProperties();
             }
-
-            DrawNonSerializedFields();
-            DrawNativeProperties();
-            DrawButtons();
         }
 
         protected void GetSerializedProperties(ref List<SerializedProperty> outSerializedProperties)


### PR DESCRIPTION
By having the fields drawing being overrideable it's easier to extend the NaughtyAttributes Custom Inspector while still maintaining extra functionalities such as Method Buttons, which are great!