### PR TITLE
ShowAssetPreview shows gameobject if a component has no preview

### DIFF
--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/ShowAssetPreviewPropertyDrawer.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/ShowAssetPreviewPropertyDrawer.cs
@@ -72,6 +72,13 @@ namespace NaughtyAttributes.Editor
                 if (property.objectReferenceValue != null)
                 {
                     Texture2D previewTexture = AssetPreview.GetAssetPreview(property.objectReferenceValue);
+                    
+                    if (previewTexture == null && property.objectReferenceValue is Component)
+                    {
+                        var gameObject = (property.objectReferenceValue as Component).gameObject;
+                        previewTexture = AssetPreview.GetAssetPreview(gameObject);
+                    }
+                    
                     return previewTexture;
                 }
 


### PR DESCRIPTION
In my scripts, I have serialized references to Components. These components live in the root gameObject of prefabs. 

If I use the `ShowAssetPreview` on a field of type `Component`, then no preview is shown. With this change, the preview of the gameObject shows correctly.

Thank you for the great work!