### PR TITLE
Added an optional format string for `[Dropdown]`

### DIFF
--- a/Assets/NaughtyAttributes/Scripts/Core/DrawerAttributes/DropdownAttribute.cs
+++ b/Assets/NaughtyAttributes/Scripts/Core/DrawerAttributes/DropdownAttribute.cs
@@ -9,14 +9,12 @@ namespace NaughtyAttributes
     {
         public string ValuesName { get; private set; }
 
-        public string DisplayPrefix { get; set; }
-        public string DisplaySuffix { get; set; }
+        public string DisplayFormat { get; set; }
 
-        public DropdownAttribute(string valuesName, string displayPrefix = "", string displaySuffix = "")
+        public DropdownAttribute(string valuesName, string displayFormat = "")
         {
             ValuesName = valuesName;
-            DisplayPrefix = displayPrefix;
-            DisplaySuffix = displaySuffix;
+            DisplayFormat = displayFormat;
         }
     }
 

--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/DropdownPropertyDrawer.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/DropdownPropertyDrawer.cs
@@ -32,11 +32,13 @@ namespace NaughtyAttributes.Editor
 
             object valuesObject = GetValues(property, dropdownAttribute.ValuesName);
             FieldInfo dropdownField = ReflectionUtility.GetField(target, property.name);
-            
-            string prefix = dropdownAttribute.DisplayPrefix;
-            string suffix = dropdownAttribute.DisplaySuffix;
 
-            Func<object, string> generateDisplayValue = v => string.Format("{0}{1}{2}", prefix, v, suffix);
+            Func<object, string> generateDisplayValue = v => v.ToString();
+
+            if (!string.IsNullOrWhiteSpace(dropdownAttribute.DisplayFormat))
+            {
+               generateDisplayValue =  v => string.Format(dropdownAttribute.DisplayFormat, v);
+            }
 
             if (AreValuesValid(valuesObject, dropdownField))
             {

--- a/Assets/NaughtyAttributes/Scripts/Test/DropdownTest.cs
+++ b/Assets/NaughtyAttributes/Scripts/Test/DropdownTest.cs
@@ -8,17 +8,24 @@ namespace NaughtyAttributes.Test
         [Dropdown("intValues")]
         public int intValue;
         
-        [Dropdown("intValues", DisplayPrefix = "Number: ")]
+        [Dropdown("intValues", "Number: {0}")]
         public int prefixedIntValue;
 
-        [Dropdown("intValues", DisplaySuffix = " Megabyte(s)")]
+        [Dropdown("intValues", "{0} Megabyte(s)")]
         public int suffixedIntValue;
 
-        [Dropdown("intValues", "Show "," Widgets")]
+        [Dropdown("intValues", "Show {0} Widgets")]
         public int surroundedIntValue;
+        
+        [Dropdown("floatValues", "Value: {0}")]
+        public float floatValue;
+        
+        [Dropdown("floatValues", "{0:0.#%}")]
+        public float formattedFloatValue;
 
 #pragma warning disable 414
         private int[] intValues = new int[] { 1, 2, 3 };
+        private float[] floatValues = new float[] { 0.1234f, 0.5648f, 1.0f };
 #pragma warning restore 414
 
         public DropdownNest1 nest1;
@@ -30,13 +37,13 @@ namespace NaughtyAttributes.Test
         [Dropdown("StringValues")]
         public string stringValue;
         
-        [Dropdown("StringValues", DisplayPrefix = "Letter: ")]
+        [Dropdown("StringValues", "Letter: {0}")]
         public string prefixedStringValue;
 
-        [Dropdown("StringValues", DisplaySuffix = " Grade")]
+        [Dropdown("StringValues", "{0} Grade")]
         public string suffixedStringValue;
 
-        [Dropdown("StringValues", "Hello ", " World")]
+        [Dropdown("StringValues", "Hello {0} World")]
         public string surroundedStringValue;
 
         private List<string> StringValues { get { return new List<string>() { "A", "B", "C" }; } }
@@ -50,13 +57,13 @@ namespace NaughtyAttributes.Test
         [Dropdown("GetVectorValues")]
         public Vector3 vectorValue;
         
-        [Dropdown("GetVectorValues", DisplayPrefix = "Go ")]
+        [Dropdown("GetVectorValues", "Go {0}")]
         public Vector3 prefixedVectorValue;
 
-        [Dropdown("GetVectorValues", DisplaySuffix = " is the way!")]
+        [Dropdown("GetVectorValues", "{0} is the way!")]
         public Vector3 suffixedVectorValue;
 
-        [Dropdown("GetVectorValues", "Go: ", ", now!")]
+        [Dropdown("GetVectorValues", "Go: {0} now!")]
         public Vector3 surroundedVectorValue;
 
         private DropdownList<Vector3> GetVectorValues()


### PR DESCRIPTION
Didn't realize that renaming a branch would auto-close the previous PR. 😅

A continuation of #286 after feedback from @rhys-vdw;

Instead of allowing the user to provide individual prefixes or suffixes to the way values are displayed by the `[Dropdown]` attribute, instead this allows them to provide a standard format string that can manipulate the values as they see fit.

This allows for more custom display for values, with minimal in-class additions by the end user:

E.g.:
![image](https://user-images.githubusercontent.com/602691/179763175-a16d8c20-062c-44b0-bc3c-9848567e8ccf.png)

Results in:

![image](https://user-images.githubusercontent.com/602691/179763219-46d1b66f-38e4-4bf8-bd45-5e8dfa16ae28.png)

and

![image](https://user-images.githubusercontent.com/602691/179763256-ba48d4a9-c573-43f1-946c-646ba47a5ee1.png)
