### PR TITLE
#325 - Fixed a bug that expandable draws label twice. 

### DIFF
--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/ExpandablePropertyDrawer.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/ExpandablePropertyDrawer.cs
@@ -108,7 +108,7 @@ namespace NaughtyAttributes.Editor
                             height = EditorGUIUtility.singleLineHeight
                         };
 
-                        EditorGUI.PropertyField(propertyRect, property, label, false);
+                        EditorGUI.PropertyField(propertyRect, property, false);
 
                         // Draw the child properties
                         if (property.isExpanded)


### PR DESCRIPTION
It may cause display error in Scriptable Wizard.

**In ExpandablePropertyDrawer.cs:**

- When drawing expandable property, it calls EditorGUI.Foldout(). It may draw property label once.
- After that , it calls EditorGUI.PropertyField() with label override. It may draw property label twice.

This problem was not discovered in inspector for the label totally overlaped when drawing twice.
But in Scriptable Wizard, the second label can't overlap on the first label （Maybe for the indent reason)

![image](https://user-images.githubusercontent.com/26408248/192440611-d2652408-2cc9-4913-b84e-753235f259b2.png)

![image](https://user-images.githubusercontent.com/26408248/192440668-2da27c74-f923-4839-85b1-f969ecdf0573.png)
