### PR TITLE
support easy buttons

### DIFF
--- a/Assets/NaughtyAttributes/Scripts/Editor/NaughtyInspector.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/NaughtyInspector.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using UnityEditor;
@@ -15,7 +17,10 @@ namespace NaughtyAttributes.Editor
         private IEnumerable<PropertyInfo> _nativeProperties;
         private IEnumerable<MethodInfo> _methods;
         private Dictionary<string, SavedBool> _foldouts = new Dictionary<string, SavedBool>();
-
+        
+        private delegate void EBDrawMethodDel(IEnumerable<object> targets);
+        private EBDrawMethodDel _ebEbDrawMethod;
+        
         protected virtual void OnEnable()
         {
             _nonSerializedFields = ReflectionUtility.GetAllFields(
@@ -26,6 +31,52 @@ namespace NaughtyAttributes.Editor
 
             _methods = ReflectionUtility.GetAllMethods(
                 target, m => m.GetCustomAttributes(typeof(ButtonAttribute), true).Length > 0);
+            
+            EasyButtonSupport();
+        }
+
+        private void EasyButtonSupport()
+        {
+            var ebDrawerType = Type.GetType("EasyButtons.Editor.ButtonsDrawer, EasyButtons.Editor");
+
+            if(ebDrawerType == null) return;
+            
+            var constructor = ebDrawerType.GetConstructor(new [] {typeof(object)});
+            if(constructor == null)
+            {
+                Debug.LogWarning("NaughtyAttributes: EasyButtons.ButtonAttribute constructor not found");
+                return;
+            }
+
+            var ebDrawer = constructor.Invoke(new[] { target });
+            if(ebDrawer == null)
+            {
+                Debug.LogWarning("NaughtyAttributes: EasyButtons.ButtonAttribute constructor failed");
+                return;
+            }
+            
+            var buttonsListField = ebDrawerType.GetField("Buttons", BindingFlags.Instance | BindingFlags.Public); 
+            if(buttonsListField == null)
+            {
+                Debug.LogWarning("NaughtyAttributes: EasyButtons.Editor.ButtonsDrawer.Buttons field not found");
+                return;
+            }
+            
+            var buttonsList = buttonsListField.GetValue(ebDrawer) as IList;
+            
+            if(buttonsList == null || buttonsList.Count == 0)
+            {
+                return;
+            }
+
+            var drawMethodInfo = ebDrawerType.GetMethod("DrawButtons", new [] { typeof(IEnumerable<object>) });
+            if(drawMethodInfo == null)
+            {
+                Debug.LogWarning("NaughtyAttributes: EasyButtons.Editor.ButtonsDrawer.DrawButtons method not found");
+                return;
+            }
+            
+            _ebEbDrawMethod = drawMethodInfo.CreateDelegate(typeof(EBDrawMethodDel), ebDrawer) as EBDrawMethodDel;
         }
 
         protected virtual void OnDisable()
@@ -173,7 +224,7 @@ namespace NaughtyAttributes.Editor
 
         protected void DrawButtons(bool drawHeader = false)
         {
-            if (_methods.Any())
+            if (_methods.Any() || _ebEbDrawMethod != null)
             {
                 if (drawHeader)
                 {
@@ -187,6 +238,8 @@ namespace NaughtyAttributes.Editor
                 {
                     NaughtyEditorGUI.Button(serializedObject.targetObject, method);
                 }
+
+                _ebEbDrawMethod?.Invoke(targets);
             }
         }
 


### PR DESCRIPTION
This PR simply tries to find [EasyButtons](https://github.com/madsbangh/EasyButtons) assembly and draws the buttons in the `NaughtyInspector` through that, if the user does not have EasyButtons installed it acts normally. 
This is to basically get access to Buttons with parameters and NaughtyInspector overrides drawer from EasyButtons, while using EasyButtons as kind of a plugin for NaughtyAttributes.

It does need a restart in my experience if EasyButtons is installed after this.

Though if usage of separate EasyButtons assembly is not wanted, I can write support for the button params separately without any external dependencies some time in the coming weeks.

