### PR TITLE
Updated NaughtInspector to be Open to Extension for Inheritors

### DIFF
--- a/Assets/NaughtyAttributes/Scripts/Editor/NaughtyInspector.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/NaughtyInspector.cs
@@ -18,7 +18,12 @@ namespace NaughtyAttributes.Editor
 
         protected virtual void OnEnable()
         {
-            _nonSerializedFields = ReflectionUtility.GetAllFields(
+            GetReferences();
+        }
+		
+		protected virtual void GetReferences()
+		{
+			_nonSerializedFields = ReflectionUtility.GetAllFields(
                 target, f => f.GetCustomAttributes(typeof(ShowNonSerializedFieldAttribute), true).Length > 0);
 
             _nativeProperties = ReflectionUtility.GetAllProperties(
@@ -26,7 +31,7 @@ namespace NaughtyAttributes.Editor
 
             _methods = ReflectionUtility.GetAllMethods(
                 target, m => m.GetCustomAttributes(typeof(ButtonAttribute), true).Length > 0);
-        }
+		}
 
         protected virtual void OnDisable()
         {
@@ -35,7 +40,12 @@ namespace NaughtyAttributes.Editor
 
         public override void OnInspectorGUI()
         {
-            GetSerializedProperties(ref _serializedProperties);
+			DrawNaughtyInspectorGUI();
+        }
+		
+		protected virtual void DrawNaughtyInspectorGUI()
+		{
+			GetSerializedProperties(ref _serializedProperties);
 
             bool anyNaughtyAttribute = _serializedProperties.Any(p => PropertyUtility.GetAttribute<INaughtyAttribute>(p) != null);
             if (!anyNaughtyAttribute)
@@ -50,9 +60,9 @@ namespace NaughtyAttributes.Editor
             DrawNonSerializedFields();
             DrawNativeProperties();
             DrawButtons();
-        }
+		}
 
-        protected void GetSerializedProperties(ref List<SerializedProperty> outSerializedProperties)
+        protected virtual void GetSerializedProperties(ref List<SerializedProperty> outSerializedProperties)
         {
             outSerializedProperties.Clear();
             using (var iterator = serializedObject.GetIterator())
@@ -68,7 +78,7 @@ namespace NaughtyAttributes.Editor
             }
         }
 
-        protected void DrawSerializedProperties()
+        protected virtual void DrawSerializedProperties()
         {
             serializedObject.Update();
 
@@ -133,7 +143,7 @@ namespace NaughtyAttributes.Editor
             serializedObject.ApplyModifiedProperties();
         }
 
-        protected void DrawNonSerializedFields(bool drawHeader = false)
+        protected virtual void DrawNonSerializedFields(bool drawHeader = false)
         {
             if (_nonSerializedFields.Any())
             {
@@ -152,7 +162,7 @@ namespace NaughtyAttributes.Editor
             }
         }
 
-        protected void DrawNativeProperties(bool drawHeader = false)
+        protected virtual void DrawNativeProperties(bool drawHeader = false)
         {
             if (_nativeProperties.Any())
             {
@@ -171,7 +181,7 @@ namespace NaughtyAttributes.Editor
             }
         }
 
-        protected void DrawButtons(bool drawHeader = false)
+        protected virtual void DrawButtons(bool drawHeader = false)
         {
             if (_methods.Any())
             {

--- a/Assets/NaughtyAttributes/Scripts/Editor/NaughtyInspector.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/NaughtyInspector.cs
@@ -18,10 +18,10 @@ namespace NaughtyAttributes.Editor
 
         protected virtual void OnEnable()
         {
-            GetReferences();
+            GetNaughtyReferences();
         }
 		
-		protected virtual void GetReferences()
+		protected virtual void GetNaughtyReferences()
 		{
 			_nonSerializedFields = ReflectionUtility.GetAllFields(
                 target, f => f.GetCustomAttributes(typeof(ShowNonSerializedFieldAttribute), true).Length > 0);


### PR DESCRIPTION
These changes allow a user to inherit from NaughtyInspector and extend the functionality without needing to modify read-only source. 

Example use case
```
    [CanEditMultipleObjects]
    [CustomEditor(typeof(Object), true, isFallback = false)]
    public class InspectorNoteEditor : NaughtyInspector
    {
        private bool isShowingNotes = true;
        private const string buttonStatePrefKey = "InspectorNoteEditor.isShowingNotes";

        protected override void OnEnable()
        {
            GetNaughtyReferences();
            isShowingNotes = EditorPrefs.GetBool(buttonStatePrefKey, true);
        }

        public override void OnInspectorGUI()
        {
            var notesAttributes = (InspectorNotesAttribute[])Attribute.GetCustomAttributes(target.GetType(), typeof(InspectorNotesAttribute));
            if (notesAttributes.Length != 0) 
                DrawNotes(notesAttributes);

            DrawNaughtyInspectorGUI();
        }
        
        private void DrawNotes(IEnumerable<InspectorNotesAttribute> notesAttributes)
        {
            var buttonContent = EditorGUIUtility.TrTextContentWithIcon(!isShowingNotes ? "Click to show notes" : "",
                "d_UnityEditor.InspectorWindow@2x");
            GUILayout.BeginHorizontal(isShowingNotes ? EditorStyles.helpBox : EditorStyles.toolbarButton);
            if (GUILayout.Button(buttonContent,
                    isShowingNotes ? EditorStyles.selectionRect : EditorStyles.centeredGreyMiniLabel, GUILayout.MinWidth(40),
                    GUILayout.ExpandHeight(true), GUILayout.ExpandWidth(!isShowingNotes)))
            {
                isShowingNotes = !isShowingNotes;
                EditorPrefs.SetBool(buttonStatePrefKey, isShowingNotes);
            }

            if (isShowingNotes)
            {
                GUILayout.BeginVertical();
                foreach (var noteAttribute in notesAttributes)
                {
                    GUI.backgroundColor = noteAttribute.messageType switch
                    {
                        InspectorNotesAttribute.MessageType.None => Color.black,
                        InspectorNotesAttribute.MessageType.Info => Color.cyan,
                        InspectorNotesAttribute.MessageType.Warning => Color.yellow,
                        InspectorNotesAttribute.MessageType.Error => Color.red,
                        _ => GUI.backgroundColor
                    };

                    EditorGUILayout.HelpBox(noteAttribute.notes, (MessageType)(int)noteAttribute.messageType);
                    if (!string.IsNullOrEmpty(noteAttribute.linkURL))
                    {
                        var buttonName = string.IsNullOrEmpty(noteAttribute.linkDisplayName)
                            ? noteAttribute.linkURL
                            : noteAttribute.linkDisplayName;
                        if (GUILayout.Button(buttonName, EditorStyles.miniButton))
                            Application.OpenURL(noteAttribute.linkURL);
                    }
                }

                GUILayout.EndVertical();
                GUI.backgroundColor = Color.white;
            }

            GUILayout.EndHorizontal();
        }
    }
```

Another example 
Override DrawSerializedProperties to skip m_Scripts property