### PR TITLE
ReadonlyExpandablePropertyDrawer: initial commit.

### DIFF
--- a/Assets/NaughtyAttributes/Scripts/Core/DrawerAttributes/ReadonlyExpandable.cs
+++ b/Assets/NaughtyAttributes/Scripts/Core/DrawerAttributes/ReadonlyExpandable.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace NaughtyAttributes
+{
+    [AttributeUsage(AttributeTargets.Field, AllowMultiple = false, Inherited = true)]
+    public class ReadonlyExpandableAttribute : DrawerAttribute
+    {
+    }
+}

--- a/Assets/NaughtyAttributes/Scripts/Core/DrawerAttributes/ReadonlyExpandable.cs.meta
+++ b/Assets/NaughtyAttributes/Scripts/Core/DrawerAttributes/ReadonlyExpandable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1cbea092418ab7140956aaa10e734828
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/ReadonlyExpandablePropertyDrawer.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/ReadonlyExpandablePropertyDrawer.cs
@@ -1,0 +1,191 @@
+using System;
+using UnityEngine;
+using UnityEditor;
+
+namespace NaughtyAttributes.Editor
+{
+    [CustomPropertyDrawer(typeof(ReadonlyExpandableAttribute))]
+    public class ReadonlyExpandablePropertyDrawer : PropertyDrawerBase
+    {
+        protected override float GetPropertyHeight_Internal(SerializedProperty property, GUIContent label)
+        {
+            if (property.objectReferenceValue == null)
+            {
+                return GetPropertyHeight(property);
+            }
+
+            Type propertyType = PropertyUtility.GetPropertyType(property);
+            if (typeof(ScriptableObject).IsAssignableFrom(propertyType))
+            {
+                ScriptableObject scriptableObject = property.objectReferenceValue as ScriptableObject;
+                if (scriptableObject == null)
+                {
+                    return GetPropertyHeight(property);
+                }
+
+                if (!property.isExpanded)
+                {
+                    return GetPropertyHeight(property);
+                }
+
+                using SerializedObject serializedObject = new SerializedObject(scriptableObject);
+                float totalHeight = EditorGUIUtility.singleLineHeight;
+
+                using var iterator = serializedObject.GetIterator();
+                if (iterator.NextVisible(true))
+                {
+                    do
+                    {
+                        SerializedProperty childProperty = serializedObject.FindProperty(iterator.name);
+                        if (childProperty.name.Equals("m_Script", StringComparison.Ordinal))
+                        {
+                            continue;
+                        }
+
+                        bool visible = PropertyUtility.IsVisible(childProperty);
+                        if (!visible)
+                        {
+                            continue;
+                        }
+
+                        float height = GetPropertyHeight(childProperty);
+                        totalHeight += height;
+                    } while (iterator.NextVisible(false));
+                }
+
+                totalHeight += EditorGUIUtility.standardVerticalSpacing;
+                return totalHeight;
+            }
+
+            return GetPropertyHeight(property) + GetHelpBoxHeight();
+        }
+
+        protected override void OnGUI_Internal(Rect rect, SerializedProperty property, GUIContent label)
+        {
+            EditorGUI.BeginProperty(rect, label, property);
+
+            if (property.objectReferenceValue == null)
+            {
+                EditorGUI.PropertyField(rect, property, label, false);
+            }
+            else
+            {
+                Type propertyType = PropertyUtility.GetPropertyType(property);
+                if (typeof(ScriptableObject).IsAssignableFrom(propertyType))
+                {
+                    ScriptableObject scriptableObject = property.objectReferenceValue as ScriptableObject;
+                    if (scriptableObject == null)
+                    {
+                        EditorGUI.PropertyField(rect, property, label, false);
+                    }
+                    else
+                    {
+                        // Draw a foldout
+                        Rect foldoutRect = new Rect
+                        {
+                            x = rect.x,
+                            y = rect.y,
+                            width = EditorGUIUtility.labelWidth,
+                            height = EditorGUIUtility.singleLineHeight
+                        };
+
+                        property.isExpanded = EditorGUI.Foldout(
+                            foldoutRect, property.isExpanded, label, toggleOnLabelClick: true);
+
+                        // Draw the scriptable object field
+                        Rect propertyRect = new Rect
+                        {
+                            x = rect.x,
+                            y = rect.y,
+                            width = rect.width,
+                            height = EditorGUIUtility.singleLineHeight
+                        };
+
+                        EditorGUI.PropertyField(propertyRect, property, label, false);
+
+                        // Draw the child properties
+                        if (property.isExpanded)
+                        {
+                            DrawChildProperties(rect, property);
+                        }
+                    }
+                }
+                else
+                {
+                    string message = $"{nameof(ReadonlyExpandableAttribute)} can only be used on scriptable objects";
+                    DrawDefaultPropertyAndHelpBox(rect, property, message, MessageType.Warning);
+                }
+            }
+
+            property.serializedObject.ApplyModifiedProperties();
+            EditorGUI.EndProperty();
+        }
+
+        private void DrawChildProperties(Rect rect, SerializedProperty property)
+        {
+            ScriptableObject scriptableObject = property.objectReferenceValue as ScriptableObject;
+            if (scriptableObject == null)
+            {
+                return;
+            }
+
+            using (new EditorGUI.DisabledScope(true))
+            {
+                Rect boxRect = new Rect
+                {
+                    x = 0.0f,
+                    y = rect.y + EditorGUIUtility.singleLineHeight,
+                    width = rect.width * 2.0f,
+                    height = rect.height - EditorGUIUtility.singleLineHeight
+                };
+
+                GUI.Box(boxRect, GUIContent.none);
+
+                using (new EditorGUI.IndentLevelScope())
+                {
+                    SerializedObject serializedObject = new SerializedObject(scriptableObject);
+                    serializedObject.Update();
+
+                    using (var iterator = serializedObject.GetIterator())
+                    {
+                        float yOffset = EditorGUIUtility.singleLineHeight;
+
+                        if (iterator.NextVisible(true))
+                        {
+                            do
+                            {
+                                SerializedProperty childProperty = serializedObject.FindProperty(iterator.name);
+                                if (childProperty.name.Equals("m_Script", StringComparison.Ordinal))
+                                {
+                                    continue;
+                                }
+
+                                bool visible = PropertyUtility.IsVisible(childProperty);
+                                if (!visible)
+                                {
+                                    continue;
+                                }
+
+                                float childHeight = GetPropertyHeight(childProperty);
+                                Rect childRect = new Rect()
+                                {
+                                    x = rect.x,
+                                    y = rect.y + yOffset,
+                                    width = rect.width,
+                                    height = childHeight
+                                };
+
+
+                                NaughtyEditorGUI.PropertyField(childRect, childProperty, true);
+
+                                yOffset += childHeight;
+                            } while (iterator.NextVisible(false));
+                        }
+                    }
+
+                    serializedObject.ApplyModifiedProperties();
+                }
+            }
+        }
+    }
+}

--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/ReadonlyExpandablePropertyDrawer.cs.meta
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/ReadonlyExpandablePropertyDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 684d56a95fab0894ba71f705268b7322
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Custom drawer for any field that references a scriptable object much like `ExpandablePropertyDrawer`. Shows the contents of the scriptable object without making the properties thereof editable.

This is how it looks in the Inspector:
![image](https://github.com/user-attachments/assets/d3d8f709-5b4a-42da-8f1e-c739100d5e68)
