### PR TITLE
Fix [ShowAssetPreview] row collapse on cold AssetPreview cache

### DIFF
--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/ShowAssetPreviewPropertyDrawer.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/ShowAssetPreviewPropertyDrawer.cs
@@ -10,15 +10,12 @@ namespace NaughtyAttributes.Editor
         {
             if (property.propertyType == SerializedPropertyType.ObjectReference)
             {
-                Texture2D previewTexture = GetAssetPreview(property);
-                if (previewTexture != null)
-                {
-                    return GetPropertyHeight(property) + GetAssetPreviewSize(property).y;
-                }
-                else
+                if (property.objectReferenceValue == null)
                 {
                     return GetPropertyHeight(property);
                 }
+
+                return GetPropertyHeight(property) + GetReservedPreviewSize(property).y;
             }
             else
             {
@@ -42,18 +39,30 @@ namespace NaughtyAttributes.Editor
 
                 EditorGUI.PropertyField(propertyRect, property, label);
 
-                Texture2D previewTexture = GetAssetPreview(property);
-                if (previewTexture != null)
+                Object target = property.objectReferenceValue;
+                if (target != null)
                 {
-                    Rect previewRect = new Rect()
+                    Texture2D previewTexture = AssetPreview.GetAssetPreview(target);
+                    if (previewTexture != null)
                     {
-                        x = rect.x + NaughtyEditorGUI.GetIndentLength(rect),
-                        y = rect.y + EditorGUIUtility.singleLineHeight,
-                        width = rect.width,
-                        height = GetAssetPreviewSize(property).y
-                    };
+                        Rect previewRect = new Rect()
+                        {
+                            x = rect.x + NaughtyEditorGUI.GetIndentLength(rect),
+                            y = rect.y + EditorGUIUtility.singleLineHeight,
+                            width = rect.width,
+                            height = GetReservedPreviewSize(property).y
+                        };
 
-                    GUI.Label(previewRect, previewTexture);
+                        GUI.Label(previewRect, previewTexture);
+                    }
+                    else if (AssetPreview.IsLoadingAssetPreview(target.GetInstanceID()))
+                    {
+                        EditorWindow focused = EditorWindow.focusedWindow;
+                        if (focused != null)
+                        {
+                            focused.Repaint();
+                        }
+                    }
                 }
             }
             else
@@ -65,46 +74,19 @@ namespace NaughtyAttributes.Editor
             EditorGUI.EndProperty();
         }
 
-        private Texture2D GetAssetPreview(SerializedProperty property)
+        private static Vector2 GetReservedPreviewSize(SerializedProperty property)
         {
-            if (property.propertyType == SerializedPropertyType.ObjectReference)
-            {
-                if (property.objectReferenceValue != null)
-                {
-                    Texture2D previewTexture = AssetPreview.GetAssetPreview(property.objectReferenceValue);
-                    return previewTexture;
-                }
+            int targetWidth = ShowAssetPreviewAttribute.DefaultWidth;
+            int targetHeight = ShowAssetPreviewAttribute.DefaultHeight;
 
-                return null;
+            ShowAssetPreviewAttribute showAssetPreviewAttribute = PropertyUtility.GetAttribute<ShowAssetPreviewAttribute>(property);
+            if (showAssetPreviewAttribute != null)
+            {
+                targetWidth = showAssetPreviewAttribute.Width;
+                targetHeight = showAssetPreviewAttribute.Height;
             }
 
-            return null;
-        }
-
-        private Vector2 GetAssetPreviewSize(SerializedProperty property)
-        {
-            Texture2D previewTexture = GetAssetPreview(property);
-            if (previewTexture == null)
-            {
-                return Vector2.zero;
-            }
-            else
-            {
-                int targetWidth = ShowAssetPreviewAttribute.DefaultWidth;
-                int targetHeight = ShowAssetPreviewAttribute.DefaultHeight;
-
-                ShowAssetPreviewAttribute showAssetPreviewAttribute = PropertyUtility.GetAttribute<ShowAssetPreviewAttribute>(property);
-                if (showAssetPreviewAttribute != null)
-                {
-                    targetWidth = showAssetPreviewAttribute.Width;
-                    targetHeight = showAssetPreviewAttribute.Height;
-                }
-
-                int width = Mathf.Clamp(targetWidth, 0, previewTexture.width);
-                int height = Mathf.Clamp(targetHeight, 0, previewTexture.height);
-
-                return new Vector2(width, height);
-            }
+            return new Vector2(targetWidth, targetHeight);
         }
     }
 }


### PR DESCRIPTION
## Summary

`AssetPreview.GetAssetPreview` is asynchronous. The first time a list of assets with `[ShowAssetPreview]` is shown the cache is cold, the call returns `null`, and `GetPropertyHeight_Internal` sizes the row to a single line. The preview that arrives a moment later then renders into the collapsed strip and overflows into neighbouring rows. Selecting another object and coming back works because by then the cache is warm.

This change:

- Reserves the configured `ShowAssetPreviewAttribute` size as soon as a reference is assigned, instead of waiting for the texture to be ready.
- Calls `EditorWindow.focusedWindow.Repaint()` while `AssetPreview.IsLoadingAssetPreview` is true so the row picks up the texture once it's ready, instead of staying blank until the next selection.

## Repro before the fix

1. Open an inspector on an asset with a list field marked `[ShowAssetPreview]` that has no previews cached this session.
2. The first paint shows preview thumbnails overflowing into adjacent rows.
3. Select another object and come back — now the rows are sized correctly.

After the fix the first paint is correct.

## Test plan

- [ ] Inspect an asset with several `[ShowAssetPreview]` list fields after a domain reload — first paint reserves the right height.
- [ ] Inspect an asset with a single `[ShowAssetPreview]` field — preview still appears and is sized correctly.
- [ ] Clear the asset reference — row collapses to a single line as before.