### PR TITLE
Extend FilePath and FolderPath attributes with relative paths and validation

### DIFF
--- a/Assets/NaughtyAttributes/Scripts/Core/DrawerAttributes/FilePathAttribute.cs
+++ b/Assets/NaughtyAttributes/Scripts/Core/DrawerAttributes/FilePathAttribute.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace NaughtyAttributes
+{
+    [AttributeUsage(AttributeTargets.Field, AllowMultiple = false, Inherited = true)]
+    public class FilePathAttribute : DrawerAttribute
+    {
+        public string Title { get; private set; }
+        public string Directory { get; private set; }
+        public string Filter { get; private set; }
+
+        public FilePathAttribute(string title = "Select file", string directory = "", string filter = "")
+        {
+            Title = title;
+            Directory = directory;
+            Filter = filter;
+        }
+    }
+}

--- a/Assets/NaughtyAttributes/Scripts/Core/DrawerAttributes/FilePathAttribute.cs
+++ b/Assets/NaughtyAttributes/Scripts/Core/DrawerAttributes/FilePathAttribute.cs
@@ -8,12 +8,16 @@ namespace NaughtyAttributes
         public string Title { get; private set; }
         public string Directory { get; private set; }
         public string Filter { get; private set; }
+        public bool RelativePath { get; private set; }
+        public bool ValidateExists { get; private set; }
 
-        public FilePathAttribute(string title = "Select file", string directory = "", string filter = "")
+        public FilePathAttribute(string title = "Select file", string directory = "", string filter = "", bool relativePath = false, bool validateExists = false)
         {
             Title = title;
             Directory = directory;
             Filter = filter;
+            RelativePath = relativePath;
+            ValidateExists = validateExists;
         }
     }
 }

--- a/Assets/NaughtyAttributes/Scripts/Core/DrawerAttributes/FilePathAttribute.cs.meta
+++ b/Assets/NaughtyAttributes/Scripts/Core/DrawerAttributes/FilePathAttribute.cs.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: cf3e631cf3684de0b845daeb8d473cab
+MonoImporter:
+  externalObjects: {}
+  executionOrder: 0
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/NaughtyAttributes/Scripts/Core/DrawerAttributes/FolderPathAttribute.cs
+++ b/Assets/NaughtyAttributes/Scripts/Core/DrawerAttributes/FolderPathAttribute.cs
@@ -7,11 +7,13 @@ namespace NaughtyAttributes
     {
         public string Title { get; private set; }
         public string DefaultPath { get; private set; }
+        public bool RelativePath { get; private set; }
 
-        public FolderPathAttribute(string title = "Select folder", string defaultPath = "")
+        public FolderPathAttribute(string title = "Select folder", string defaultPath = "", bool relativePath = false)
         {
             Title = title;
             DefaultPath = defaultPath;
+            RelativePath = relativePath;
         }
     }
 }

--- a/Assets/NaughtyAttributes/Scripts/Core/DrawerAttributes/FolderPathAttribute.cs
+++ b/Assets/NaughtyAttributes/Scripts/Core/DrawerAttributes/FolderPathAttribute.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace NaughtyAttributes
+{
+    [AttributeUsage(AttributeTargets.Field, AllowMultiple = false, Inherited = true)]
+    public class FolderPathAttribute : DrawerAttribute
+    {
+        public string Title { get; private set; }
+        public string DefaultPath { get; private set; }
+
+        public FolderPathAttribute(string title = "Select folder", string defaultPath = "")
+        {
+            Title = title;
+            DefaultPath = defaultPath;
+        }
+    }
+}

--- a/Assets/NaughtyAttributes/Scripts/Core/DrawerAttributes/FolderPathAttribute.cs.meta
+++ b/Assets/NaughtyAttributes/Scripts/Core/DrawerAttributes/FolderPathAttribute.cs.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c7a6d962db974eaabe4cb6d3324a1259
+MonoImporter:
+  externalObjects: {}
+  executionOrder: 0
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/FilePathPropertyDrawer.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/FilePathPropertyDrawer.cs
@@ -62,6 +62,10 @@ namespace NaughtyAttributes.Editor
                     if (!string.IsNullOrEmpty(selectedPath))
                     {
                         property.stringValue = selectedPath;
+                        property.serializedObject.ApplyModifiedProperties();
+                        EditorGUIUtility.editingTextField = false;
+                        GUIUtility.keyboardControl = 0;
+                        GUI.changed = true;
                     }
                 }
             }

--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/FilePathPropertyDrawer.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/FilePathPropertyDrawer.cs
@@ -8,14 +8,20 @@ namespace NaughtyAttributes.Editor
     public class FilePathPropertyDrawer : PropertyDrawerBase
     {
         private const string TypeWarningMessage = "{0} must be a string";
+        private const string FileNotFoundWarningMessage = "{0} does not exist";
         private const string BrowseButtonLabel = "Browse";
         private const float BrowseButtonWidth = 60.0f;
 
         protected override float GetPropertyHeight_Internal(SerializedProperty property, GUIContent label)
         {
-            return (property.propertyType == SerializedPropertyType.String)
-                ? GetPropertyHeight(property)
-                : GetPropertyHeight(property) + GetHelpBoxHeight();
+            if (property.propertyType != SerializedPropertyType.String)
+            {
+                return GetPropertyHeight(property) + GetHelpBoxHeight();
+            }
+
+            return ShouldShowFileNotFoundWarning(property)
+                ? GetPropertyHeight(property) + EditorGUIUtility.standardVerticalSpacing + GetHelpBoxHeight()
+                : GetPropertyHeight(property);
         }
 
         protected override void OnGUI_Internal(Rect rect, SerializedProperty property, GUIContent label)
@@ -61,12 +67,28 @@ namespace NaughtyAttributes.Editor
 
                     if (!string.IsNullOrEmpty(selectedPath))
                     {
+                        selectedPath = filePathAttribute.RelativePath
+                            ? NaughtyPathUtility.GetProjectRelativePath(selectedPath)
+                            : NaughtyPathUtility.NormalizePath(selectedPath);
+
                         property.stringValue = selectedPath;
                         property.serializedObject.ApplyModifiedProperties();
                         EditorGUIUtility.editingTextField = false;
                         GUIUtility.keyboardControl = 0;
                         GUI.changed = true;
                     }
+                }
+
+                if (ShouldShowFileNotFoundWarning(property))
+                {
+                    Rect helpBoxRect = new Rect(
+                        rect.x + NaughtyEditorGUI.GetIndentLength(rect),
+                        rect.y + EditorGUIUtility.singleLineHeight + EditorGUIUtility.standardVerticalSpacing,
+                        rect.width - NaughtyEditorGUI.GetIndentLength(rect),
+                        GetHelpBoxHeight());
+
+                    string message = string.Format(FileNotFoundWarningMessage, property.stringValue);
+                    NaughtyEditorGUI.HelpBox(helpBoxRect, message, MessageType.Warning, property.serializedObject.targetObject);
                 }
             }
             else
@@ -76,6 +98,17 @@ namespace NaughtyAttributes.Editor
             }
 
             EditorGUI.EndProperty();
+        }
+
+        private static bool ShouldShowFileNotFoundWarning(SerializedProperty property)
+        {
+            FilePathAttribute filePathAttribute = PropertyUtility.GetAttribute<FilePathAttribute>(property);
+            if (filePathAttribute == null || !filePathAttribute.ValidateExists || string.IsNullOrEmpty(property.stringValue))
+            {
+                return false;
+            }
+
+            return !File.Exists(NaughtyPathUtility.GetProjectAbsolutePath(property.stringValue));
         }
     }
 }

--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/FilePathPropertyDrawer.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/FilePathPropertyDrawer.cs
@@ -1,0 +1,77 @@
+using UnityEngine;
+using UnityEditor;
+using System.IO;
+
+namespace NaughtyAttributes.Editor
+{
+    [CustomPropertyDrawer(typeof(FilePathAttribute))]
+    public class FilePathPropertyDrawer : PropertyDrawerBase
+    {
+        private const string TypeWarningMessage = "{0} must be a string";
+        private const string BrowseButtonLabel = "Browse";
+        private const float BrowseButtonWidth = 60.0f;
+
+        protected override float GetPropertyHeight_Internal(SerializedProperty property, GUIContent label)
+        {
+            return (property.propertyType == SerializedPropertyType.String)
+                ? GetPropertyHeight(property)
+                : GetPropertyHeight(property) + GetHelpBoxHeight();
+        }
+
+        protected override void OnGUI_Internal(Rect rect, SerializedProperty property, GUIContent label)
+        {
+            EditorGUI.BeginProperty(rect, label, property);
+
+            if (property.propertyType == SerializedPropertyType.String)
+            {
+                FilePathAttribute filePathAttribute = PropertyUtility.GetAttribute<FilePathAttribute>(property);
+
+                Rect labelRect = new Rect(
+                    rect.x,
+                    rect.y,
+                    EditorGUIUtility.labelWidth,
+                    EditorGUIUtility.singleLineHeight);
+
+                Rect textFieldRect = new Rect(
+                    rect.x + EditorGUIUtility.labelWidth,
+                    rect.y,
+                    rect.width - EditorGUIUtility.labelWidth - BrowseButtonWidth - NaughtyEditorGUI.HorizontalSpacing,
+                    EditorGUIUtility.singleLineHeight);
+
+                Rect buttonRect = new Rect(
+                    rect.x + rect.width - BrowseButtonWidth,
+                    rect.y,
+                    BrowseButtonWidth,
+                    EditorGUIUtility.singleLineHeight);
+
+                EditorGUI.LabelField(labelRect, label);
+
+                EditorGUI.BeginChangeCheck();
+                string newValue = EditorGUI.TextField(textFieldRect, property.stringValue);
+                if (EditorGUI.EndChangeCheck())
+                {
+                    property.stringValue = newValue;
+                }
+
+                if (GUI.Button(buttonRect, BrowseButtonLabel))
+                {
+                    string path = property.stringValue;
+                    string directory = string.IsNullOrEmpty(path) ? filePathAttribute.Directory : Path.GetDirectoryName(path);
+                    string selectedPath = EditorUtility.OpenFilePanel(filePathAttribute.Title, directory, filePathAttribute.Filter);
+
+                    if (!string.IsNullOrEmpty(selectedPath))
+                    {
+                        property.stringValue = selectedPath;
+                    }
+                }
+            }
+            else
+            {
+                string message = string.Format(TypeWarningMessage, property.name);
+                DrawDefaultPropertyAndHelpBox(rect, property, message, MessageType.Warning);
+            }
+
+            EditorGUI.EndProperty();
+        }
+    }
+}

--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/FilePathPropertyDrawer.cs.meta
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/FilePathPropertyDrawer.cs.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4957cadb94114dd1bdee1869b6a446ee
+MonoImporter:
+  externalObjects: {}
+  executionOrder: 0
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/FolderPathPropertyDrawer.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/FolderPathPropertyDrawer.cs
@@ -62,6 +62,10 @@ namespace NaughtyAttributes.Editor
                     if (!string.IsNullOrEmpty(selectedPath))
                     {
                         property.stringValue = selectedPath;
+                        property.serializedObject.ApplyModifiedProperties();
+                        EditorGUIUtility.editingTextField = false;
+                        GUIUtility.keyboardControl = 0;
+                        GUI.changed = true;
                     }
                 }
             }

--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/FolderPathPropertyDrawer.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/FolderPathPropertyDrawer.cs
@@ -1,0 +1,77 @@
+using UnityEngine;
+using UnityEditor;
+using System.IO;
+
+namespace NaughtyAttributes.Editor
+{
+    [CustomPropertyDrawer(typeof(FolderPathAttribute))]
+    public class FolderPathPropertyDrawer : PropertyDrawerBase
+    {
+        private const string TypeWarningMessage = "{0} must be a string";
+        private const string BrowseButtonLabel = "Browse";
+        private const float BrowseButtonWidth = 60.0f;
+
+        protected override float GetPropertyHeight_Internal(SerializedProperty property, GUIContent label)
+        {
+            return (property.propertyType == SerializedPropertyType.String)
+                ? GetPropertyHeight(property)
+                : GetPropertyHeight(property) + GetHelpBoxHeight();
+        }
+
+        protected override void OnGUI_Internal(Rect rect, SerializedProperty property, GUIContent label)
+        {
+            EditorGUI.BeginProperty(rect, label, property);
+
+            if (property.propertyType == SerializedPropertyType.String)
+            {
+                FolderPathAttribute folderPathAttribute = PropertyUtility.GetAttribute<FolderPathAttribute>(property);
+
+                Rect labelRect = new Rect(
+                    rect.x,
+                    rect.y,
+                    EditorGUIUtility.labelWidth,
+                    EditorGUIUtility.singleLineHeight);
+
+                Rect textFieldRect = new Rect(
+                    rect.x + EditorGUIUtility.labelWidth,
+                    rect.y,
+                    rect.width - EditorGUIUtility.labelWidth - BrowseButtonWidth - NaughtyEditorGUI.HorizontalSpacing,
+                    EditorGUIUtility.singleLineHeight);
+
+                Rect buttonRect = new Rect(
+                    rect.x + rect.width - BrowseButtonWidth,
+                    rect.y,
+                    BrowseButtonWidth,
+                    EditorGUIUtility.singleLineHeight);
+
+                EditorGUI.LabelField(labelRect, label);
+
+                EditorGUI.BeginChangeCheck();
+                string newValue = EditorGUI.TextField(textFieldRect, property.stringValue);
+                if (EditorGUI.EndChangeCheck())
+                {
+                    property.stringValue = newValue;
+                }
+
+                if (GUI.Button(buttonRect, BrowseButtonLabel))
+                {
+                    string path = property.stringValue;
+                    string defaultPath = string.IsNullOrEmpty(path) ? folderPathAttribute.DefaultPath : path;
+                    string selectedPath = EditorUtility.OpenFolderPanel(folderPathAttribute.Title, defaultPath, "");
+
+                    if (!string.IsNullOrEmpty(selectedPath))
+                    {
+                        property.stringValue = selectedPath;
+                    }
+                }
+            }
+            else
+            {
+                string message = string.Format(TypeWarningMessage, property.name);
+                DrawDefaultPropertyAndHelpBox(rect, property, message, MessageType.Warning);
+            }
+
+            EditorGUI.EndProperty();
+        }
+    }
+}

--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/FolderPathPropertyDrawer.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/FolderPathPropertyDrawer.cs
@@ -61,6 +61,10 @@ namespace NaughtyAttributes.Editor
 
                     if (!string.IsNullOrEmpty(selectedPath))
                     {
+                        selectedPath = folderPathAttribute.RelativePath
+                            ? NaughtyPathUtility.GetProjectRelativePath(selectedPath)
+                            : NaughtyPathUtility.NormalizePath(selectedPath);
+
                         property.stringValue = selectedPath;
                         property.serializedObject.ApplyModifiedProperties();
                         EditorGUIUtility.editingTextField = false;

--- a/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/FolderPathPropertyDrawer.cs.meta
+++ b/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/FolderPathPropertyDrawer.cs.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 89ff688b9b4d4f5c98864943747b4fe8
+MonoImporter:
+  externalObjects: {}
+  executionOrder: 0
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/NaughtyAttributes/Scripts/Editor/Utility/NaughtyPathUtility.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/Utility/NaughtyPathUtility.cs
@@ -1,0 +1,46 @@
+using System;
+using System.IO;
+using UnityEngine;
+
+namespace NaughtyAttributes.Editor
+{
+    public static class NaughtyPathUtility
+    {
+        public static string GetProjectRelativePath(string path)
+        {
+            string projectPath = GetProjectPathWithTrailingSeparator();
+            string fullPath = Path.GetFullPath(path);
+
+            return fullPath.StartsWith(projectPath, StringComparison.OrdinalIgnoreCase)
+                ? NormalizePath(fullPath.Substring(projectPath.Length))
+                : NormalizePath(path);
+        }
+
+        public static string GetProjectAbsolutePath(string path)
+        {
+            if (string.IsNullOrEmpty(path) || Path.IsPathRooted(path))
+            {
+                return path;
+            }
+
+            string projectPath = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            return Path.GetFullPath(Path.Combine(projectPath, path));
+        }
+
+        public static string NormalizePath(string path)
+        {
+            return path.Replace(Path.DirectorySeparatorChar, '/').Replace(Path.AltDirectorySeparatorChar, '/');
+        }
+
+        private static string GetProjectPathWithTrailingSeparator()
+        {
+            string projectPath = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            if (!projectPath.EndsWith(Path.DirectorySeparatorChar.ToString()))
+            {
+                projectPath += Path.DirectorySeparatorChar;
+            }
+
+            return projectPath;
+        }
+    }
+}

--- a/Assets/NaughtyAttributes/Scripts/Editor/Utility/NaughtyPathUtility.cs.meta
+++ b/Assets/NaughtyAttributes/Scripts/Editor/Utility/NaughtyPathUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 45e346b4970e4dc0ba5e5a18134be6b2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/NaughtyAttributes/Scripts/Test/FilePathTest.cs
+++ b/Assets/NaughtyAttributes/Scripts/Test/FilePathTest.cs
@@ -1,0 +1,31 @@
+using UnityEngine;
+
+namespace NaughtyAttributes.Test
+{
+    public class FilePathTest : MonoBehaviour
+    {
+        [FilePath]
+        public string filePath0;
+
+        [FilePath("Select a C# file", "", "cs")]
+        public string filePath1;
+
+        public FilePathNest1 nest1;
+    }
+
+    [System.Serializable]
+    public class FilePathNest1
+    {
+        [FilePath("Select a text file", "", "txt")]
+        public string filePath2;
+
+        public FilePathNest2 nest2;
+    }
+
+    [System.Serializable]
+    public struct FilePathNest2
+    {
+        [FilePath]
+        public string filePath3;
+    }
+}

--- a/Assets/NaughtyAttributes/Scripts/Test/FilePathTest.cs
+++ b/Assets/NaughtyAttributes/Scripts/Test/FilePathTest.cs
@@ -10,16 +10,16 @@ namespace NaughtyAttributes.Test
         [FilePath("Select a C# file", "", "cs")]
         public string filePath1;
 
-        [FilePath("Select a relative file", "", "", true)]
+        [FilePath("Select a relative file", "", "", relativePath: true)]
         public string relativeFilePath;
 
-        [FilePath("Select an existing file", "", "", false, true)]
+        [FilePath("Select an existing file", "", "", validateExists: true)]
         public string existingFilePath;
 
-        [FilePath("Select an existing relative file", "", "", true, true)]
+        [FilePath("Select an existing relative file", "", "", relativePath: true, validateExists: true)]
         public string existingRelativeFilePath;
 
-        [FolderPath("Select a relative folder", "", true)]
+        [FolderPath("Select a relative folder", "", relativePath: true)]
         public string relativeFolderPath;
 
         public FilePathNest1 nest1;

--- a/Assets/NaughtyAttributes/Scripts/Test/FilePathTest.cs
+++ b/Assets/NaughtyAttributes/Scripts/Test/FilePathTest.cs
@@ -10,6 +10,18 @@ namespace NaughtyAttributes.Test
         [FilePath("Select a C# file", "", "cs")]
         public string filePath1;
 
+        [FilePath("Select a relative file", "", "", true)]
+        public string relativeFilePath;
+
+        [FilePath("Select an existing file", "", "", false, true)]
+        public string existingFilePath;
+
+        [FilePath("Select an existing relative file", "", "", true, true)]
+        public string existingRelativeFilePath;
+
+        [FolderPath("Select a relative folder", "", true)]
+        public string relativeFolderPath;
+
         public FilePathNest1 nest1;
     }
 

--- a/Assets/NaughtyAttributes/Scripts/Test/FilePathTest.cs.meta
+++ b/Assets/NaughtyAttributes/Scripts/Test/FilePathTest.cs.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9e317697ba5549a39facb0dc9fada789
+MonoImporter:
+  externalObjects: {}
+  executionOrder: 0
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/NaughtyAttributes/Scripts/Test/FolderPathTest.cs
+++ b/Assets/NaughtyAttributes/Scripts/Test/FolderPathTest.cs
@@ -1,0 +1,31 @@
+using UnityEngine;
+
+namespace NaughtyAttributes.Test
+{
+    public class FolderPathTest : MonoBehaviour
+    {
+        [FolderPath]
+        public string folderPath0;
+
+        [FolderPath("Select Assets folder", "Assets")]
+        public string folderPath1;
+
+        public FolderPathNest1 nest1;
+    }
+
+    [System.Serializable]
+    public class FolderPathNest1
+    {
+        [FolderPath]
+        public string folderPath2;
+
+        public FolderPathNest2 nest2;
+    }
+
+    [System.Serializable]
+    public struct FolderPathNest2
+    {
+        [FolderPath]
+        public string folderPath3;
+    }
+}

--- a/Assets/NaughtyAttributes/Scripts/Test/FolderPathTest.cs.meta
+++ b/Assets/NaughtyAttributes/Scripts/Test/FolderPathTest.cs.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3aec37d623cb45dfbfaa3c80a183f1f8
+MonoImporter:
+  externalObjects: {}
+  executionOrder: 0
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
This PR extends `FilePathAttribute` and `FolderPathAttribute` with additional drawer options.

### Added
- `FilePathAttribute.relativePath`
- Stores selected file paths relative to the Unity project root when enabled.
- For project assets, this results in paths like `Assets/...`.
- `FolderPathAttribute.relativePath`
- Stores selected folder paths relative to the Unity project root when enabled.
- `FilePathAttribute.validateExists`
- Shows a warning in the Inspector when the field has a value but the referenced file does
  not exist.

### Changed
- Selected paths are applied immediately after using the Browse button.
- Stored paths are normalized to use forward slashes.
- Added sample fields in `FilePathTest` for manual testing.

## Compatibility
Existing behavior remains unchanged by default:
- `relativePath` defaults to `false`
- `validateExists` defaults to `false`

## Testing
Tested in Unity 6000.3.1f1.
- Verified scripts compile without errors.
- Verified relative file paths are stored as `Assets/...`.
- Verified relative folder paths are stored as `Assets/...`.
- Verified missing file paths show an Inspector warning when `validateExists` is enabled.